### PR TITLE
container: Replace `AccessGroup` with `BasicACL

### DIFF
--- a/container/service.proto
+++ b/container/service.proto
@@ -42,8 +42,8 @@ message PutRequest {
     // Rules define storage policy for the object inside the container.
     netmap.PlacementRule rules               = 4 [(gogoproto.nullable) = false];
 
-    // Container ACL.
-    AccessGroup Group                        = 5 [(gogoproto.nullable) = false];
+    // BasicACL of the container.
+    uint32 BasicACL                          = 5;
 
     // RequestMetaHeader contains information about request meta headers (should be embedded into message)
     service.RequestMetaHeader Meta           = 98 [(gogoproto.embed) = true, (gogoproto.nullable) = false];

--- a/container/types.proto
+++ b/container/types.proto
@@ -18,18 +18,7 @@ message Container {
     uint64 Capacity            = 3;
     // Rules define storage policy for the object inside the container.
     netmap.PlacementRule Rules = 4 [(gogoproto.nullable) = false];
-    // Container ACL.
-    AccessControlList List     = 5 [(gogoproto.nullable) = false];
-}
-
-message AccessGroup {
-    // Group access mode.
-    uint32 AccessMode         = 1;
-    // Group members.
-    repeated bytes UserGroup  = 2 [(gogoproto.customtype) = "OwnerID", (gogoproto.nullable) = false];
-}
-
-message AccessControlList {
-    // List of access groups.
-    repeated AccessGroup List = 1 [(gogoproto.nullable) = false];
+    // BasicACL with access control rules for owner, system, others and
+    // permission bits for bearer token and extended ACL.
+    uint32 BasicACL            = 5;
 }

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -21,8 +21,6 @@
 - [container/types.proto](#container/types.proto)
 
   - Messages
-    - [AccessControlList](#container.AccessControlList)
-    - [AccessGroup](#container.AccessGroup)
     - [Container](#container.Container)
     
 
@@ -166,7 +164,7 @@ via consensus in inner ring nodes
 | Capacity | [uint64](#uint64) |  | Capacity defines amount of data that can be stored in the container (doesn't used for now). |
 | OwnerID | [bytes](#bytes) |  | OwnerID is a wallet address |
 | rules | [netmap.PlacementRule](#netmap.PlacementRule) |  | Rules define storage policy for the object inside the container. |
-| Group | [AccessGroup](#container.AccessGroup) |  | Container ACL. |
+| BasicACL | [uint32](#uint32) |  | BasicACL of the container. |
 | Meta | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | RequestMetaHeader contains information about request meta headers (should be embedded into message) |
 | Verify | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message) |
 
@@ -196,29 +194,6 @@ via consensus in inner ring nodes
  <!-- end services -->
 
 
-<a name="container.AccessControlList"></a>
-
-### Message AccessControlList
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| List | [AccessGroup](#container.AccessGroup) | repeated | List of access groups. |
-
-
-<a name="container.AccessGroup"></a>
-
-### Message AccessGroup
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| AccessMode | [uint32](#uint32) |  | Group access mode. |
-| UserGroup | [bytes](#bytes) | repeated | Group members. |
-
-
 <a name="container.Container"></a>
 
 ### Message Container
@@ -231,7 +206,7 @@ The Container service definition.
 | Salt | [bytes](#bytes) |  | Salt is a nonce for unique container id calculation. |
 | Capacity | [uint64](#uint64) |  | Capacity defines amount of data that can be stored in the container (doesn't used for now). |
 | Rules | [netmap.PlacementRule](#netmap.PlacementRule) |  | Rules define storage policy for the object inside the container. |
-| List | [AccessControlList](#container.AccessControlList) |  | Container ACL. |
+| BasicACL | [uint32](#uint32) |  | BasicACL with access control rules for owner, system, others and permission bits for bearer token and extended ACL. |
 
  <!-- end messages -->
 


### PR DESCRIPTION
With new ACL conception, access control lists in NeoFS defined as a required **basic ACL** and optional **extended ACL**.

Basic ACL must be set up in container structure. It is a bit mask stored in 32-bit unsigned integer.

Seven nibbles represent seven object operations: 
- get,
- put,
- head,
- search,
- delete,
- range,
- range-hash.

Every nibble defines access rules for three targets: **user**, **owner**, **others** and has permission bit for **bearer token**.

There is a permission bit for extended ACL and three unused bits.