### PR TITLE
Add gRPC method to change current node state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,21 @@ GOGOPROTO_URL=https://github.com/gogo/protobuf/archive/$(GOGOPROTO_VERSION).tar.
 .PHONY: deps docgen
 
 deps:
-	@echo "=> Prepare"
+	@echo "⇒ Prepare"
 	@rm -rf ./vendor/github.com/gogo/protobuf
 	@rm -rf ./vendor/github.com/nspcc-dev/netmap
 	@mkdir -p ./vendor/github.com/gogo/protobuf
 	@mkdir -p ./vendor/github.com/nspcc-dev/netmap
 
-	@echo "=> Download"
+	@echo "⇒ Download"
 	@curl -sL -o ./vendor/gogo.tar.gz $(GOGOPROTO_URL)
 	@curl -sL -o ./vendor/netmap.tar.gz $(NETMAP_URL)
 
-	@echo "=> Vendoring"
+	@echo "⇒ Vendoring"
 	@tar -xzf ./vendor/gogo.tar.gz --strip-components 1 -C ./vendor/github.com/gogo/protobuf
 	@tar -xzf ./vendor/netmap.tar.gz --strip-components 1 -C ./vendor/github.com/nspcc-dev/netmap
 
-	@echo "=> Cleanup"
+	@echo "⇒ Cleanup"
 	@rm ./vendor/gogo.tar.gz
 	@rm ./vendor/netmap.tar.gz
 

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -297,7 +297,7 @@ in distributed system.
 | ----- | ---- | ----- | ----------- |
 | Object | [Object](#object.Object) |  | Object with at least container id and owner id fields |
 | Token | [session.Token](#session.Token) |  | Token with session public key and user's signature |
-| CopiesNumber | [uint32](#uint32) |  | Number of the object copies to store within RPC call (zero is processed according to the placement rules) |
+| CopiesNumber | [uint32](#uint32) |  | Number of the object copies to store within the RPC call (zero is processed according to the placement rules) |
 
 
 <a name="object.PutResponse"></a>

--- a/proto-docs/state.md
+++ b/proto-docs/state.md
@@ -8,6 +8,8 @@
     - [Status](#state.Status)
     
   - Messages
+    - [ChangeStateRequest](#state.ChangeStateRequest)
+    - [ChangeStateResponse](#state.ChangeStateResponse)
     - [DumpRequest](#state.DumpRequest)
     - [DumpResponse](#state.DumpResponse)
     - [DumpVarsRequest](#state.DumpVarsRequest)
@@ -34,7 +36,8 @@
 <a name="state.Status"></a>
 
 ### Service "state.Status"
-Status service provides node's healthcheck and status info
+Status service provides node's healthcheck and status info.
+TODO: decide how to describe auth and were contains permissions.
 
 ```
 rpc Netmap(NetmapRequest) returns (.bootstrap.SpreadMap);
@@ -42,6 +45,7 @@ rpc Metrics(MetricsRequest) returns (MetricsResponse);
 rpc HealthCheck(HealthRequest) returns (HealthResponse);
 rpc DumpConfig(DumpRequest) returns (DumpResponse);
 rpc DumpVars(DumpVarsRequest) returns (DumpVarsResponse);
+rpc ChangeState(ChangeStateRequest) returns (ChangeStateResponse);
 
 ```
 
@@ -85,7 +89,36 @@ The request should be signed.
 | Name | Input | Output |
 | ---- | ----- | ------ |
 | DumpVars | [DumpVarsRequest](#state.DumpVarsRequest) | [DumpVarsResponse](#state.DumpVarsResponse) |
+#### Method ChangeState
+
+ChangeState allows to change current node state of node.
+To permit access, used server config options.
+The request should be signed.
+
+| Name | Input | Output |
+| ---- | ----- | ------ |
+| ChangeState | [ChangeStateRequest](#state.ChangeStateRequest) | [ChangeStateResponse](#state.ChangeStateResponse) |
  <!-- end services -->
+
+
+<a name="state.ChangeStateRequest"></a>
+
+### Message ChangeStateRequest
+ChangeStateRequest contains a new state of node.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| state | [ChangeStateRequest.State](#state.ChangeStateRequest.State) |  | State is a new state of node. |
+| Meta | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | RequestMetaHeader contains information about request meta headers (should be embedded into message) |
+| Verify | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message) |
+
+
+<a name="state.ChangeStateResponse"></a>
+
+### Message ChangeStateResponse
+ChangeStateResponse is an empty response, that returns when RPC invoked without errors.
+
 
 
 <a name="state.DumpRequest"></a>
@@ -197,6 +230,19 @@ NetmapRequest message to request current node netmap
 | Verify | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message) |
 
  <!-- end messages -->
+
+
+<a name="state.ChangeStateRequest.State"></a>
+
+### ChangeStateRequest.State
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Unknown | 0 | Unknown is default value. Does nothing. |
+| Online | 1 | Online used when need to set node to the online state. |
+| Offline | 2 | Offline used when need to set node to the offline state. |
+
 
  <!-- end enums -->
 

--- a/state/service.proto
+++ b/state/service.proto
@@ -10,7 +10,8 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 option (gogoproto.stable_marshaler_all) = true;
 
-// Status service provides node's healthcheck and status info
+// Status service provides node's healthcheck and status info.
+// TODO: decide how to describe auth and were contains permissions.
 service Status {
     // Netmap request allows to receive current [bootstrap.SpreadMap](bootstrap.md#bootstrap.SpreadMap)
     rpc Netmap(NetmapRequest) returns (bootstrap.SpreadMap);
@@ -27,6 +28,10 @@ service Status {
     // To permit access, used server config options.
     // The request should be signed.
     rpc DumpVars(DumpVarsRequest) returns (DumpVarsResponse);
+    // ChangeState allows to change current node state of node.
+    // To permit access, used server config options.
+    // The request should be signed.
+    rpc ChangeState(ChangeStateRequest) returns (ChangeStateResponse);
 }
 
 // NetmapRequest message to request current node netmap
@@ -95,3 +100,25 @@ message DumpVarsRequest {
 message DumpVarsResponse {
     bytes Variables = 1;
 }
+
+// ChangeStateRequest contains a new state of node.
+message ChangeStateRequest {
+    enum State {
+        // Unknown is default value. Does nothing.
+        Unknown = 0;
+        // Online used when need to set node to the online state.
+        Online = 1;
+        // Offline used when need to set node to the offline state.
+        Offline = 2;
+    }
+
+    // State is a new state of node.
+    State state = 1;
+    // RequestMetaHeader contains information about request meta headers (should be embedded into message)
+    service.RequestMetaHeader Meta           = 98 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
+    // RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message)
+    service.RequestVerificationHeader Verify = 99 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
+}
+
+// ChangeStateResponse is an empty response, that returns when RPC invoked without errors.
+message ChangeStateResponse {}


### PR DESCRIPTION
The main objective of this method is to allow to control and manage the state of the node by its owner.

- if the user is not declared in the settings, the system returns an access error.
- if the new status is not defined or is not known, the system notifies about that.
- if the new status is known to the system, it will be applied and the node will change the current status.