### PR TITLE
object: remove Token field from PutRequest.PutHeader and DeleteRequest

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -79,10 +79,8 @@ message PutRequest {
     message PutHeader {
         // Object with at least container id and owner id fields
         Object Object       = 1;
-        // Token with session public key and user's signature
-        service.Token Token = 2;
         // Number of the object copies to store within the RPC call (zero is processed according to the placement rules)
-        uint32 CopiesNumber = 3;
+        uint32 CopiesNumber = 2;
     }
 
     oneof R {
@@ -109,8 +107,6 @@ message DeleteRequest {
     refs.Address Address                     = 1 [(gogoproto.nullable) = false];
     // OwnerID is a wallet address
     bytes OwnerID                            = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "OwnerID"];
-    // Token with session public key and user's signature
-    service.Token Token                      = 3;
     // RequestMetaHeader contains information about request meta headers (should be embedded into message)
     service.RequestMetaHeader Meta           = 98 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
     // RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message)

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -376,7 +376,7 @@ in distributed system.
 | UserHeader | [UserHeader](#object.UserHeader) |  | UserHeader is a set of KV headers defined by user |
 | Transform | [Transform](#object.Transform) |  | Transform defines transform operation (e.g. payload split) |
 | Tombstone | [Tombstone](#object.Tombstone) |  | Tombstone header that set up in deleted objects |
-| Token | [service.Token](#service.Token) |  | Token header that contains session token |
+| Token | [service.Token](#service.Token) |  | Token header contains token of the session within which the object was created |
 | HomoHash | [bytes](#bytes) |  | HomoHash is a homomorphic hash of original object payload |
 | PayloadChecksum | [bytes](#bytes) |  | PayloadChecksum of actual object's payload |
 | Integrity | [IntegrityHeader](#object.IntegrityHeader) |  | Integrity header with checksum of all above headers in the object |

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -149,7 +149,6 @@ calculated for XORed data.
 | ----- | ---- | ----- | ----------- |
 | Address | [refs.Address](#refs.Address) |  | Address of object (container id + object id) |
 | OwnerID | [bytes](#bytes) |  | OwnerID is a wallet address |
-| Token | [service.Token](#service.Token) |  | Token with session public key and user's signature |
 | Meta | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | RequestMetaHeader contains information about request meta headers (should be embedded into message) |
 | Verify | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message) |
 
@@ -294,7 +293,6 @@ in distributed system.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | Object | [Object](#object.Object) |  | Object with at least container id and owner id fields |
-| Token | [service.Token](#service.Token) |  | Token with session public key and user's signature |
 | CopiesNumber | [uint32](#uint32) |  | Number of the object copies to store within the RPC call (zero is processed according to the placement rules) |
 
 


### PR DESCRIPTION
 Session token is presented in RequestVerificationHeader, therefore its presence in request bodies is redundant.