### PR TITLE
service: remove gogoproto customname from embedded Token.Info field

### DIFF
--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -107,7 +107,7 @@ User token granting rights for object manipulation
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| info | [Token.Info](#service.Token.Info) |  | Info is a grouped information about token |
+| TokenInfo | [Token.Info](#service.Token.Info) |  | Info is a grouped information about token |
 | Signature | [bytes](#bytes) |  | Signature is a signature of session token information |
 
 

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -68,8 +68,8 @@ message Token {
         bytes SessionKey = 7;
     }
 
-    // Info is a grouped information about token
-    Info info = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false, (gogoproto.customname) = "Info"];
+    // TokenInfo is a grouped information about token
+    Info TokenInfo = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
 
     // Signature is a signature of session token information
     bytes Signature = 8;


### PR DESCRIPTION
This commit:

  * removes gogoproto customname option from embedded Token.Info field;

  * renames Info field of Token message to TokenInfo.