### PR TITLE
Change Session.Create RPC

### DIFF
--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -17,6 +17,7 @@
     - [RequestVerificationHeader.Signature](#service.RequestVerificationHeader.Signature)
     - [Token](#service.Token)
     - [Token.Info](#service.Token.Info)
+    - [TokenLifetime](#service.TokenLifetime)
     
 
 - [Scalar Value Types](#scalar-value-types)
@@ -123,9 +124,20 @@ User token granting rights for object manipulation
 | OwnerID | [bytes](#bytes) |  | OwnerID is an owner of manipulation object |
 | verb | [Token.Info.Verb](#service.Token.Info.Verb) |  | Verb is a type of request for which the token is issued |
 | Address | [refs.Address](#refs.Address) |  | Address is an object address for which token is issued |
-| Created | [uint64](#uint64) |  | Created is an initial epoch of token lifetime |
-| ValidUntil | [uint64](#uint64) |  | ValidUntil is a last epoch of token lifetime |
+| Lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
 | SessionKey | [bytes](#bytes) |  | SessionKey is a public key of session key |
+
+
+<a name="service.TokenLifetime"></a>
+
+### Message TokenLifetime
+TokenLifetime carries a group of lifetime parameters of the token
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| Created | [uint64](#uint64) |  | Created carries an initial epoch of token lifetime |
+| ValidUntil | [uint64](#uint64) |  | ValidUntil carries a last epoch of token lifetime |
 
  <!-- end messages -->
 

--- a/proto-docs/session.md
+++ b/proto-docs/session.md
@@ -30,22 +30,13 @@
 
 
 ```
-rpc Create(stream CreateRequest) returns (stream CreateResponse);
+rpc Create(CreateRequest) returns (CreateResponse);
 
 ```
 
 #### Method Create
 
-Create is a method that used to open a trusted session to manipulate
-an object. In order to put or delete object client have to obtain session
-token with trusted node. Trusted node will modify client's object
-(add missing headers, checksums, homomorphic hash) and sign id with
-session key. Session is established during 4-step handshake in one gRPC stream
-
-- First client stream message SHOULD BE type of `CreateRequest_Init`.
-- First server stream message SHOULD BE type of `CreateResponse_Unsigned`.
-- Second client stream message SHOULD BE type of `CreateRequest_Signed`.
-- Second server stream message SHOULD BE type of `CreateResponse_Result`.
+Create opens new session between the client and the server
 
 | Name | Input | Output |
 | ---- | ----- | ------ |
@@ -56,13 +47,13 @@ session key. Session is established during 4-step handshake in one gRPC stream
 <a name="session.CreateRequest"></a>
 
 ### Message CreateRequest
-
+CreateRequest carries an information necessary for opening a session
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| Init | [service.Token](#service.Token) |  | Init is a message to initialize session opening. Carry: owner of manipulation object; ID of manipulation object; token lifetime bounds. |
-| Signed | [service.Token](#service.Token) |  | Signed Init message response (Unsigned) from server with user private key |
+| OwnerID | [bytes](#bytes) |  | OwnerID carries an identifier of a session initiator |
+| Lifetime | [service.TokenLifetime](#service.TokenLifetime) |  | Lifetime carries a lifetime of the session |
 | Meta | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | RequestMetaHeader contains information about request meta headers (should be embedded into message) |
 | Verify | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message) |
 
@@ -70,13 +61,13 @@ session key. Session is established during 4-step handshake in one gRPC stream
 <a name="session.CreateResponse"></a>
 
 ### Message CreateResponse
-
+CreateResponse carries an information about the opened session
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| Unsigned | [service.Token](#service.Token) |  | Unsigned token with token ID and session public key generated on server side |
-| Result | [service.Token](#service.Token) |  | Result is a resulting token which can be used for object placing through an trusted intermediary |
+| ID | [bytes](#bytes) |  | ID carries an identifier of session token |
+| SessionKey | [bytes](#bytes) |  | SessionKey carries a session public key |
 
  <!-- end messages -->
 

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -58,14 +58,11 @@ message Token {
         // Address is an object address for which token is issued
         refs.Address Address = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "Address"];
 
-        // Created is an initial epoch of token lifetime
-        uint64 Created = 5;
-
-        // ValidUntil is a last epoch of token lifetime
-        uint64 ValidUntil = 6;
+        // Lifetime is a lifetime of the session
+        TokenLifetime Lifetime = 5 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
 
         // SessionKey is a public key of session key
-        bytes SessionKey = 7;
+        bytes SessionKey = 6;
     }
 
     // TokenInfo is a grouped information about token
@@ -73,6 +70,15 @@ message Token {
 
     // Signature is a signature of session token information
     bytes Signature = 8;
+}
+
+// TokenLifetime carries a group of lifetime parameters of the token
+message TokenLifetime {
+    // Created carries an initial epoch of token lifetime
+    uint64 Created = 1;
+
+    // ValidUntil carries a last epoch of token lifetime
+    uint64 ValidUntil = 2;
 }
 
 // TODO: for variable token types and version redefine message

--- a/session/service.proto
+++ b/session/service.proto
@@ -11,42 +11,29 @@ option (gogoproto.stable_marshaler_all) = true;
 
 
 service Session {
-    // Create is a method that used to open a trusted session to manipulate
-    // an object. In order to put or delete object client have to obtain session
-    // token with trusted node. Trusted node will modify client's object
-    // (add missing headers, checksums, homomorphic hash) and sign id with
-    // session key. Session is established during 4-step handshake in one gRPC stream
-    //
-    // - First client stream message SHOULD BE type of `CreateRequest_Init`.
-    // - First server stream message SHOULD BE type of `CreateResponse_Unsigned`.
-    // - Second client stream message SHOULD BE type of `CreateRequest_Signed`.
-    // - Second server stream message SHOULD BE type of `CreateResponse_Result`.
-    rpc Create (stream CreateRequest) returns (stream CreateResponse);
+    // Create opens new session between the client and the server
+    rpc Create (CreateRequest) returns (CreateResponse);
 }
 
-
+// CreateRequest carries an information necessary for opening a session
 message CreateRequest {
-    // Message should be one of
-    oneof Message {
-        // Init is a message to initialize session opening. Carry:
-        // owner of manipulation object;
-        // ID of manipulation object;
-        // token lifetime bounds.
-        service.Token Init = 1;
-        // Signed Init message response (Unsigned) from server with user private key
-        service.Token Signed = 2;
-    }
+    // OwnerID carries an identifier of a session initiator
+    bytes OwnerID = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "OwnerID"];
+
+    // Lifetime carries a lifetime of the session
+    service.TokenLifetime Lifetime = 2 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
+
     // RequestMetaHeader contains information about request meta headers (should be embedded into message)
     service.RequestMetaHeader Meta           = 98 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
     // RequestVerificationHeader is a set of signatures of every NeoFS Node that processed request (should be embedded into message)
     service.RequestVerificationHeader Verify = 99 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
 }
 
+// CreateResponse carries an information about the opened session
 message CreateResponse {
-    oneof Message {
-        // Unsigned token with token ID and session public key generated on server side
-        service.Token Unsigned = 1;
-        // Result is a resulting token which can be used for object placing through an trusted intermediary
-        service.Token Result = 2;
-    }
+    // ID carries an identifier of session token
+    bytes ID = 1 [(gogoproto.customtype) = "TokenID", (gogoproto.nullable) = false];
+
+    // SessionKey carries a session public key
+    bytes SessionKey = 2;
 }


### PR DESCRIPTION
Summary:

- put token lifetime to a separate message;

- make `Session.Create` RPC to be unary message;

- make `session.CreateRequest` message to carry owner ID and token lifetime;

- make `session.CreateResponse` message to carry token ID and public session key. 