### PR TITLE
service: add OwnerKey byte field to TokenInfo message

### DIFF
--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -126,6 +126,7 @@ User token granting rights for object manipulation
 | Address | [refs.Address](#refs.Address) |  | Address is an object address for which token is issued |
 | Lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
 | SessionKey | [bytes](#bytes) |  | SessionKey is a public key of session key |
+| OwnerKey | [bytes](#bytes) |  | OwnerKey is a public key of the token owner |
 
 
 <a name="service.TokenLifetime"></a>

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -63,6 +63,9 @@ message Token {
 
         // SessionKey is a public key of session key
         bytes SessionKey = 6;
+
+        // OwnerKey is a public key of the token owner
+        bytes OwnerKey = 7;
     }
 
     // TokenInfo is a grouped information about token


### PR DESCRIPTION
`OwnerKey` field of `Token.TokenInfo` message is going to be used for quick access to the public key of the owner.