### PR TITLE
[#33] Remove unused headers

### DIFF
--- a/accounting/service.proto
+++ b/accounting/service.proto
@@ -25,14 +25,6 @@ service Accounting {
 message BalanceRequest {
     // Carries user identifier in NeoFS system for which the balance is requested.
     refs.OwnerID OwnerID = 1;
-
-    // Carries request meta information. Header data is used only to regulate message
-    // transport and does not affect request execution.
-    service.RequestMetaHeader MetaHeader = 98;
-
-    // Carries request verification information. This header is used to authenticate
-    // the nodes of the message route and check the correctness of transmission.
-    service.RequestVerificationHeader VerifyHeader = 99;
 }
 
 // Decimal represents the decimal numbers.

--- a/proto-docs/accounting.md
+++ b/proto-docs/accounting.md
@@ -60,8 +60,6 @@ to the requirements from the system specification.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | OwnerID | [refs.OwnerID](#refs.OwnerID) |  | Carries user identifier in NeoFS system for which the balance is requested. |
-| MetaHeader | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
-| VerifyHeader | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
 
 
 <a name="accounting.BalanceResponse"></a>


### PR DESCRIPTION
Remove MetaHeader and VerifyHeader from balance request as these fields are also
removed from all container related requests.

Signed-off-by: Stanislav Bogatyrev <stanislav@nspcc.ru>