### PR TITLE
Session token context

### DIFF
--- a/object/types.proto
+++ b/object/types.proto
@@ -50,7 +50,7 @@ message Header {
             // session_token carries token of the session within which the object was created.
             // If session token is presented in object, it acts as the user's proof of the
             // correctness of the creator_key.
-            service.Token session_token = 3;
+            service.SessionToken session_token = 3;
 
             // creator_key carries public key of the object creator in a binary format.
             bytes creator_key = 4;

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -443,7 +443,7 @@ Integrity groups evidence of the integrity of an object's structure.
 | ----- | ---- | ----- | ----------- |
 | payload_checksum | [bytes](#bytes) |  | payload_checksum carries the checksum of object payload bytes. Changing any byte of the payload changes the checksum. It is calculated as a SHA-256 hash over payload bytes. |
 | header_checksum | [bytes](#bytes) |  | header_checksum carries checksum of the object header structure. It covers all object attributes. Changing any field of the object except CreatorKey and ChecksumSignature changes the checksum. payload_checksum and header_checksum cannot be merged due to the need to verify the header in the absence of a payload (e.g. in object.Head rpc). It is calculated as a SHA-256 hash over marshaled object header with cut creator_key and checksum_signature. |
-| session_token | [service.Token](#service.Token) |  | session_token carries token of the session within which the object was created. If session token is presented in object, it acts as the user's proof of the correctness of the creator_key. |
+| session_token | [service.SessionToken](#service.SessionToken) |  | session_token carries token of the session within which the object was created. If session token is presented in object, it acts as the user's proof of the correctness of the creator_key. |
 | creator_key | [bytes](#bytes) |  | creator_key carries public key of the object creator in a binary format. |
 | checksum_signature | [bytes](#bytes) |  | checksum_signature carries signature of the structure checksum by the object creator. |
 

--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -147,10 +147,10 @@ User token granting rights for object manipulation
 | id | [bytes](#bytes) |  | ID is a token identifier. valid UUIDv4 represented in bytes |
 | owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the manipulation object owner. |
 | verb | [Token.Info.Verb](#service.Token.Info.Verb) |  | Verb is a type of request for which the token is issued |
-| address | [refs.Address](#refs.Address) |  | Address is an object address for which token is issued |
 | lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
 | session_key | [bytes](#bytes) |  | SessionKey is a public key of session key |
 | owner_key | [bytes](#bytes) |  | OwnerKey is a public key of the token owner |
+| object_address | [refs.Address](#refs.Address) |  | object_address represents the object session context. |
 
 
 <a name="service.TokenLifetime"></a>

--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -174,13 +174,13 @@ Verb is an enumeration of session request types
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| PUT | 0 | Put refers to object.Put RPC call |
-| GET | 1 | Get refers to object.Get RPC call |
-| HEAD | 2 | Head refers to object.Head RPC call |
-| SEARCH | 3 | Search refers to object.Search RPC call |
-| DELETE | 4 | Delete refers to object.Delete RPC call |
-| RANGE | 5 | Range refers to object.GetRange RPC call |
-| RANGEHASH | 6 | RangeHash refers to object.GetRangeHash RPC call |
+| OBJECT_PUT | 0 | Refers to object.Put RPC call |
+| OBJECT_GET | 1 | Refers to object.Get RPC call |
+| OBJECT_HEAD | 2 | Refers to object.Head RPC call |
+| OBJECT_SEARCH | 3 | Refers to object.Search RPC call |
+| OBJECT_DELETE | 4 | Refers to object.Delete RPC call |
+| OBJECT_RANGE | 5 | Refers to object.GetRange RPC call |
+| OBJECT_RANGEHASH | 6 | Refers to object.GetRangeHash RPC call |
 
 
  <!-- end enums -->

--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -145,7 +145,7 @@ Represents the NeoFS session token.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [bytes](#bytes) |  | ID is a token identifier. valid UUIDv4 represented in bytes |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the manipulation object owner. |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the session author. |
 | verb | [SessionToken.Info.Verb](#service.SessionToken.Info.Verb) |  | Verb is a type of request for which the token is issued |
 | lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
 | session_key | [bytes](#bytes) |  | SessionKey is a public key of session key |

--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -17,8 +17,8 @@
     - [BearerTokenMsg.Info](#service.BearerTokenMsg.Info)
     - [RequestVerificationHeader](#service.RequestVerificationHeader)
     - [RequestVerificationHeader.Signature](#service.RequestVerificationHeader.Signature)
-    - [Token](#service.Token)
-    - [Token.Info](#service.Token.Info)
+    - [SessionToken](#service.SessionToken)
+    - [SessionToken.Info](#service.SessionToken.Info)
     - [TokenLifetime](#service.TokenLifetime)
     
 
@@ -108,7 +108,7 @@ RequestVerificationHeader is a set of signatures of every NeoFS Node that proces
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | signatures | [RequestVerificationHeader.Signature](#service.RequestVerificationHeader.Signature) | repeated | Signatures is a set of signatures of every passed NeoFS Node |
-| token | [Token](#service.Token) |  | Token is a token of the session within which the request is sent |
+| token | [SessionToken](#service.SessionToken) |  | Token is a token of the session within which the request is sent |
 | bearer | [BearerTokenMsg](#service.BearerTokenMsg) |  | Bearer is a Bearer token of the request |
 
 
@@ -124,21 +124,21 @@ RequestVerificationHeader is a set of signatures of every NeoFS Node that proces
 | sign | [bytes](#bytes) |  | Sign is signature of the request or session key. |
 
 
-<a name="service.Token"></a>
+<a name="service.SessionToken"></a>
 
-### Message Token
-User token granting rights for object manipulation
+### Message SessionToken
+Represents the NeoFS session token.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| token_info | [Token.Info](#service.Token.Info) |  | token_info is a grouped information about token |
+| token_info | [SessionToken.Info](#service.SessionToken.Info) |  | token_info is a grouped information about token |
 | signature | [bytes](#bytes) |  | Signature is a signature of session token information |
 
 
-<a name="service.Token.Info"></a>
+<a name="service.SessionToken.Info"></a>
 
-### Message Token.Info
+### Message SessionToken.Info
 
 
 
@@ -146,7 +146,7 @@ User token granting rights for object manipulation
 | ----- | ---- | ----- | ----------- |
 | id | [bytes](#bytes) |  | ID is a token identifier. valid UUIDv4 represented in bytes |
 | owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the manipulation object owner. |
-| verb | [Token.Info.Verb](#service.Token.Info.Verb) |  | Verb is a type of request for which the token is issued |
+| verb | [SessionToken.Info.Verb](#service.SessionToken.Info.Verb) |  | Verb is a type of request for which the token is issued |
 | lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
 | session_key | [bytes](#bytes) |  | SessionKey is a public key of session key |
 | owner_key | [bytes](#bytes) |  | OwnerKey is a public key of the token owner |
@@ -167,9 +167,9 @@ TokenLifetime carries a group of lifetime parameters of the token
  <!-- end messages -->
 
 
-<a name="service.Token.Info.Verb"></a>
+<a name="service.SessionToken.Info.Verb"></a>
 
-### Token.Info.Verb
+### SessionToken.Info.Verb
 Verb is an enumeration of session request types
 
 | Name | Number | Description |

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -22,14 +22,14 @@ message RequestVerificationHeader {
     repeated Signature signatures = 1;
 
     // Token is a token of the session within which the request is sent
-    Token token = 2;
+    SessionToken token = 2;
 
     // Bearer is a Bearer token of the request
     BearerTokenMsg bearer = 3;
 }
 
-// User token granting rights for object manipulation
-message Token {
+// Represents the NeoFS session token.
+message SessionToken {
     message Info {
         // ID is a token identifier. valid UUIDv4 represented in bytes
         bytes id = 1;

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -58,17 +58,20 @@ message Token {
         // Verb is a type of request for which the token is issued
         Verb verb = 3;
 
-        // Address is an object address for which token is issued
-        refs.Address address = 4;
-
         // Lifetime is a lifetime of the session
-        TokenLifetime lifetime = 5;
+        TokenLifetime lifetime = 4;
 
         // SessionKey is a public key of session key
-        bytes session_key = 6;
+        bytes session_key = 5;
 
         // OwnerKey is a public key of the token owner
-        bytes owner_key = 7;
+        bytes owner_key = 6;
+
+        // Carries context of the session.
+        oneof context {
+            // object_address represents the object session context.
+            refs.Address object_address = 7;
+        }
     }
 
     // token_info is a grouped information about token

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -34,7 +34,7 @@ message SessionToken {
         // ID is a token identifier. valid UUIDv4 represented in bytes
         bytes id = 1;
 
-        // OwnerID carries identifier of the manipulation object owner.
+        // OwnerID carries identifier of the session initiator.
         refs.OwnerID owner_id = 2;
 
         // Verb is an enumeration of session request types

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -39,20 +39,20 @@ message Token {
 
         // Verb is an enumeration of session request types
         enum Verb {
-            // Put refers to object.Put RPC call
-            PUT = 0;
-            // Get refers to object.Get RPC call
-            GET = 1;
-            // Head refers to object.Head RPC call
-            HEAD = 2;
-            // Search refers to object.Search RPC call
-            SEARCH = 3;
-            // Delete refers to object.Delete RPC call
-            DELETE = 4;
-            // Range refers to object.GetRange RPC call
-            RANGE = 5;
-            // RangeHash refers to object.GetRangeHash RPC call
-            RANGEHASH = 6;
+            // Refers to object.Put RPC call
+            OBJECT_PUT = 0;
+            // Refers to object.Get RPC call
+            OBJECT_GET = 1;
+            // Refers to object.Head RPC call
+            OBJECT_HEAD = 2;
+            // Refers to object.Search RPC call
+            OBJECT_SEARCH = 3;
+            // Refers to object.Delete RPC call
+            OBJECT_DELETE = 4;
+            // Refers to object.GetRange RPC call
+            OBJECT_RANGE = 5;
+            // Refers to object.GetRangeHash RPC call
+            OBJECT_RANGEHASH = 6;
         }
 
         // Verb is a type of request for which the token is issued

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -78,7 +78,7 @@ message Token {
     Info token_info = 1;
 
     // Signature is a signature of session token information
-    bytes signature = 8;
+    bytes signature = 2;
 }
 
 // TokenLifetime carries a group of lifetime parameters of the token


### PR DESCRIPTION
## Proposal
In the current version of the format, a session token is issued to a specific address of an object, which creates an inseparable connection between sessions and object operations. To unify the session mechanism, it is required to abstract the token from the object.
## Summary
Change `Token.Info.address` field of type `refs.Address` with `oneof` enumeration of session contexts. In the initial version, only the object context is available. Additional contexts can be added without losing backward compatibility.