### PR TITLE
Add body messages to API requests

### DIFF
--- a/accounting/service.proto
+++ b/accounting/service.proto
@@ -6,6 +6,8 @@ option go_package = "github.com/nspcc-dev/neofs-api-go/accounting";
 option csharp_namespace = "NeoFS.API.Accounting";
 
 import "refs/types.proto";
+import "service/meta.proto";
+import "service/verify.proto";
 
 // The service provides methods for obtaining information
 // about the account balance in NeoFS system.
@@ -22,8 +24,23 @@ service Accounting {
 // To gain access to the requested information, the request body must be formed
 // according to the requirements from the system specification.
 message BalanceRequest {
-  // Carries user identifier in NeoFS system for which the balance is requested.
-  refs.OwnerID owner_id = 1;
+  message Body {
+    // Carries user identifier in NeoFS system for which the balance
+    // is requested.
+    refs.OwnerID owner_id = 1;
+  }
+
+  // Body of the balance request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 // Decimal represents the decimal numbers.
@@ -39,6 +56,20 @@ message Decimal {
 //
 // The amount of funds is calculated in decimal numbers.
 message BalanceResponse {
-  // Carries the amount of funds on the account.
-  Decimal balance = 1;
+  message Body {
+    // Carries the amount of funds on the account.
+    Decimal balance = 1;
+  }
+
+  // Body of the balance response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }

--- a/container/service.proto
+++ b/container/service.proto
@@ -8,6 +8,8 @@ option csharp_namespace = "NeoFS.API.Container";
 import "acl/types.proto";
 import "container/types.proto";
 import "refs/types.proto";
+import "service/meta.proto";
+import "service/verify.proto";
 
 // Service provides API to access container smart-contract in morph chain
 // via NeoFS node.
@@ -42,74 +44,242 @@ service Service {
 }
 
 message PutRequest {
-  // Container to create in NeoFS.
-  container.Container container = 1;
+  message Body {
+    // Container to create in NeoFS.
+    container.Container container = 1;
 
-  // Public Key of container owner. It can be public key of the owner
-  // or it can be public key that bound in neofs.id smart-contract.
-  bytes public_key = 2;
+    // Public Key of container owner. It can be public key of the owner
+    // or it can be public key that bound in neofs.id smart-contract.
+    bytes public_key = 2;
 
-  // Signature of stable-marshalled container according to RFC-6979.
-  bytes signature = 3;
+    // Signature of stable-marshalled container according to RFC-6979.
+    bytes signature = 3;
+  }
+
+  // Body of container put request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message PutResponse {
-  // container_id carries identifier of the new container.
-  refs.ContainerID container_id = 1;
+  message Body {
+    // container_id carries identifier of the new container.
+    refs.ContainerID container_id = 1;
+  }
+
+  // Body of container put response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message DeleteRequest {
-  // container_id carries identifier of the container to delete from NeoFS.
-  refs.ContainerID container_id = 1;
+  message Body {
+    // container_id carries identifier of the container to delete
+    // from NeoFS.
+    refs.ContainerID container_id = 1;
 
-  // Signature of container id according to RFC-6979.
-  bytes signature = 2;
+    // Signature of container id according to RFC-6979.
+    bytes signature = 2;
+  }
+
+  // Body of container delete request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 // DeleteResponse is empty because delete operation is asynchronous and done
 // via consensus in inner ring nodes
-message DeleteResponse {}
+message DeleteResponse {
+  message Body {}
+
+  // Body of container delete response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
+}
 
 message GetRequest {
-  // container_id carries identifier of the container to get.
-  refs.ContainerID container_id = 1;
+  message Body {
+    // container_id carries identifier of the container to get.
+    refs.ContainerID container_id = 1;
+  }
+
+  // Body of container get request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message GetResponse {
-  // Container that has been requested.
-  container.Container container = 1;
+  message Body {
+    // Container that has been requested.
+    container.Container container = 1;
+  }
+
+  // Body of container get response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message ListRequest {
-  // owner_id carries identifier of the container owner.
-  refs.OwnerID owner_id = 1;
+  message Body {
+    // owner_id carries identifier of the container owner.
+    refs.OwnerID owner_id = 1;
+  }
+
+  // Body of list containers request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message ListResponse {
-  // ContainerIDs carries list of identifiers of the containers that belong
-  // to the owner.
-  repeated refs.ContainerID container_ids = 1;
+  message Body {
+    // ContainerIDs carries list of identifiers of the containers that belong to the owner.
+    repeated refs.ContainerID container_ids = 1;
+  }
+
+  // Body of list containers response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message SetExtendedACLRequest {
-  // Extended ACL to set for the container.
-  acl.EACLTable eacl = 1;
+  message Body {
+    // Extended ACL to set for the container.
+    acl.EACLTable eacl = 1;
 
-  // Signature of stable-marshalled Extended ACL according to RFC-6979.
-  bytes signature = 2;
+    // Signature of stable-marshalled Extended ACL according to RFC-6979.
+    bytes signature = 2;
+  }
+
+  // Body of set extended acl request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
-message SetExtendedACLResponse {}
+message SetExtendedACLResponse {
+  message Body { }
+
+  // Body of set extended acl response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
+}
 
 message GetExtendedACLRequest {
-  // container_id carries identifier of the container that has Extended ACL.
-  refs.ContainerID container_id = 1;
+  message Body {
+    // container_id carries identifier of the container that has Extended ACL.
+    refs.ContainerID container_id = 1;
+  }
+
+  // Body of get extended acl request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
+
+  // Carries request verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message GetExtendedACLResponse {
-  // Extended ACL that has been requested if it was set up.
-  acl.EACLTable eacl = 1;
+  message Body {
+    // Extended ACL that has been requested if it was set up.
+    acl.EACLTable eacl = 1;
 
-  // Signature of stable-marshalled Extended ACL according to RFC-6979.
-  bytes signature = 2;
+    // Signature of stable-marshalled Extended ACL according to RFC-6979.
+    bytes signature = 2;
+  }
+
+  // Body of get extended acl response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }

--- a/object/service.proto
+++ b/object/service.proto
@@ -5,8 +5,8 @@ package object;
 option go_package = "github.com/nspcc-dev/neofs-api-go/object";
 option csharp_namespace = "NeoFS.API.Object";
 
-import "refs/types.proto";
 import "object/types.proto";
+import "refs/types.proto";
 import "service/meta.proto";
 import "service/verify.proto";
 
@@ -53,154 +53,248 @@ service Service {
 }
 
 message GetRequest {
-  // Carries the address of the requested object.
-  refs.Address address = 1;
+  message Body {
+    // Carries the address of the requested object.
+    refs.Address address = 1;
 
-  // Carries the raw option flag of the request.
-  // Raw request is sent to receive only the objects
-  // that are physically stored on the server.
-  bool raw = 2;
+    // Carries the raw option flag of the request.
+    // Raw request is sent to receive only the objects
+    // that are physically stored on the server.
+    bool raw = 2;
+  }
+
+  // Body of get object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message GetResponse {
-  // Carries the single message of the response stream.
-  oneof ObjectPart {
-    // Carries the object header.
-    Header header = 1;
+  message Body {
+    // Carries the single message of the response stream.
+    oneof ObjectPart {
+      // Carries the object header.
+      Header header = 1;
 
-    // Carries part of the object payload.
-    bytes chunk = 2;
+      // Carries part of the object payload.
+      bytes chunk = 2;
+    }
   }
+
+  // Body of get object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message PutRequest {
-  // Groups initialization parameters of object placement in NeoFS.
-  message Init {
-    // Carries the header of the object to save in the system.
-    Header header = 1;
+  message Body {
+    // Groups initialization parameters of object placement in NeoFS.
+    message Init {
+      // Carries the header of the object to save in the system.
+      Header header = 1;
 
-    // Carries the number of the object copies to store
-    // within the RPC call. Default zero value is processed according
-    // to the container placement rules.
-    uint32 copies_number = 2;
+      // Carries the number of the object copies to store
+      // within the RPC call. Default zero value is processed according
+      // to the container placement rules.
+      uint32 copies_number = 2;
+    }
+
+    // Carries the single part of the query stream.
+    oneof Part {
+      // Carries the initialization parameters of the object stream.
+      Init init = 1;
+
+      // Carries part of the object payload.
+      bytes chunk = 2;
+    }
   }
 
-  // Carries the single part of the query stream.
-  oneof Part {
-    // Carries the initialization parameters of the object stream.
-    Init init = 1;
-
-    // Carries part of the object payload.
-    bytes chunk = 2;
-  }
+  // Body of put object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message PutResponse {
-  // Carries identifier of the saved object.
-  // It is used to access an object in the container.
-  refs.ObjectID object_id = 1;
+  message Body {
+    // Carries identifier of the saved object.
+    // It is used to access an object in the container.
+    refs.ObjectID object_id = 1;
+  }
+
+  // Body of put object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message DeleteRequest {
-  // Carries the address of the object to be deleted.
-  refs.Address address = 1;
+  message Body {
+    // Carries the address of the object to be deleted.
+    refs.Address address = 1;
 
-  // Carries identifier the object owner.
-  refs.OwnerID owner_id = 2;
+    // Carries identifier the object owner.
+    refs.OwnerID owner_id = 2;
+  }
+
+  // Body of delete object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 // DeleteResponse is empty because we cannot guarantee permanent object removal
 // in distributed system.
 message DeleteResponse {
+  message Body { }
+
+  // Body of delete object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message HeadRequest {
-  // Carries the address of the object with the requested header.
-  refs.Address address = 1;
+  message Body {
+    // Carries the address of the object with the requested header.
+    refs.Address address = 1;
 
-  // Carries the option to crop header to main part.
-  bool main_only = 2;
+    // Carries the option to crop header to main part.
+    bool main_only = 2;
 
-  // Carries the raw option flag of the request.
-  // Raw request is sent to receive only the headers of the objects
-  // that are physically stored on the server.
-  bool raw = 3;
+    // Carries the raw option flag of the request.
+    // Raw request is sent to receive only the headers of the objects
+    // that are physically stored on the server.
+    bool raw = 3;
+  }
+
+  // Body of head object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message HeadResponse {
-  // Carries the requested object header.
-  Header header = 1;
+  message Body {
+    // Carries the requested object header.
+    Header header = 1;
+  }
+
+  // Body of head object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message SearchRequest {
-  // Carries search container identifier.
-  refs.ContainerID container_id = 1;
+  message Body {
+    // Carries search container identifier.
+    refs.ContainerID container_id = 1;
 
-  message Query {
-    uint32 version = 1;
+    message Query {
+      uint32 version = 1;
 
-    message Filter {
-      enum MatchType {
-        MATCH_UNKNOWN = 0;
-        STRING_EQUAL = 1;
+      message Filter {
+        enum MatchType {
+          MATCH_UNKNOWN = 0;
+          STRING_EQUAL = 1;
+        }
+
+        MatchType match_type = 1;
+
+        string name = 2;
+
+        string value = 3;
       }
 
-      MatchType match_type = 1;
-
-      string name = 2;
-
-      string value = 3;
+      repeated Filter filters = 2;
     }
 
-    repeated Filter filters = 2;
+    Query query = 2;
   }
 
-  Query query = 2;
+  // Body of search object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message SearchResponse {
-  // Carries list of object identifiers that match the search query.
-  repeated refs.ObjectID id_list = 1;
+  message Body {
+    // Carries list of object identifiers that match the search query.
+    repeated refs.ObjectID id_list = 1;
+  }
+
+  // Body of search object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 // Range groups the parameters of object payload range.
@@ -213,47 +307,85 @@ message Range {
 }
 
 message GetRangeRequest {
-  // Address carries address of the object that contains the requested payload range.
-  refs.Address address = 1;
+  message Body {
+    // Address carries address of the object that contains the requested payload range.
+    refs.Address address = 1;
 
-  // Range carries the parameters of the requested payload range.
-  Range range = 2;
+    // Range carries the parameters of the requested payload range.
+    Range range = 2;
+  }
+
+  // Body of get range object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message GetRangeResponse {
-  // Carries part of the object payload.
-  bytes chunk = 1;
+  message Body {
+    // Carries part of the object payload.
+    bytes chunk = 1;
+  }
+
+  // Body of get range object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 
 message GetRangeHashRequest {
-  // Carries address of the object that contains the requested payload range.
-  refs.Address address = 1;
+  message Body {
+    // Carries address of the object that contains the requested payload range.
+    refs.Address address = 1;
 
-  // Carries the list of object payload range to calculate homomorphic hash.
-  repeated Range ranges = 2;
+    // Carries the list of object payload range to calculate homomorphic hash.
+    repeated Range ranges = 2;
 
-  // Carries binary salt to XOR object payload ranges before hash calculation.
-  bytes salt = 3;
+    // Carries binary salt to XOR object payload ranges before hash calculation.
+    bytes salt = 3;
+  }
+
+  // Body of get range hash object request message.
+  Body body = 1;
 
   // Carries request meta information. Header data is used only to regulate message
   // transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 message GetRangeHashResponse {
-  // Carries list of homomorphic hashes in a binary format.
-  repeated bytes hash_list = 1;
+  message Body {
+    // Carries list of homomorphic hashes in a binary format.
+    repeated bytes hash_list = 1;
+  }
+
+  // Body of get range hash object response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }
 

--- a/session/service.proto
+++ b/session/service.proto
@@ -5,9 +5,9 @@ package session;
 option go_package = "github.com/nspcc-dev/neofs-api-go/session";
 option csharp_namespace = "NeoFS.API.Session";
 
+import "refs/types.proto";
 import "service/meta.proto";
 import "service/verify.proto";
-import "refs/types.proto";
 
 service Session {
   // Create opens new session between the client and the server.
@@ -16,26 +16,45 @@ service Session {
 
 // CreateRequest carries an information necessary for opening a session.
 message CreateRequest {
-  // Carries an identifier of a session initiator.
-  refs.OwnerID owner_id = 1;
+  message Body {
+    // Carries an identifier of a session initiator.
+    refs.OwnerID owner_id = 1;
 
-  // Carries a lifetime of the session.
-  service.TokenLifetime lifetime = 2;
+    // Carries a lifetime of the session.
+    service.TokenLifetime lifetime = 2;
+  }
 
-  // Carries request meta information. Header data is used only to regulate
-  // message transport and does not affect request execution.
-  service.RequestMetaHeader meta_header = 98;
+  // Body of create session token request message.
+  Body body = 1;
+
+  // Carries request meta information. Header data is used only to regulate message
+  // transport and does not affect request execution.
+  service.RequestMetaHeader meta_header = 2;
 
   // Carries request verification information. This header is used to authenticate
   // the nodes of the message route and check the correctness of transmission.
-  service.RequestVerificationHeader verify_header = 99;
+  service.RequestVerificationHeader verify_header = 3;
 }
 
 // CreateResponse carries an information about the opened session.
 message CreateResponse {
-  // id carries an identifier of session token.
-  bytes id = 1;
+  message Body {
+    // id carries an identifier of session token.
+    bytes id = 1;
 
-  // session_key carries a session public key.
-  bytes session_key = 2;
+    // session_key carries a session public key.
+    bytes session_key = 2;
+  }
+
+  // Body of create session token response message.
+  Body body = 1;
+
+  // Carries response meta information. Header data is used only to regulate
+  // message transport and does not affect request execution.
+  service.ResponseMetaHeader meta_header = 2;
+
+  // Carries response verification information. This header is used to
+  // authenticate the nodes of the message route and check the correctness
+  // of transmission.
+  service.ResponseVerificationHeader verify_header = 3;
 }


### PR DESCRIPTION
Body messages divide requests and responses into payload scope and transport-meta scope, which include meta header and signatures. NeoFS nodes and clients can verify transmission via transport-meta scope and then work only with payload scope, that stored in `body` field of the request.

Merge this PR when transport-meta-scope of `ResponseVerificationHeader` and `ResponseMetaHeader` will be ready.