### PR TITLE
Add Matryoshka-style request and response headers

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -31,7 +31,7 @@ message PlacementRule {
 
         Operation op = 1;
 
-        oneof Args {
+        oneof args {
           string value = 2;
           SimpleFilters f_args = 3;
         }

--- a/object/service.proto
+++ b/object/service.proto
@@ -86,7 +86,7 @@ message GetResponse {
       Header header = 3;
     }
     // Carries the single message of the response stream.
-    oneof ObjectPart {
+    oneof object_part {
       // Initialization parameters of the object stream.
       Init init =1;
       // Part of the object payload.
@@ -123,7 +123,7 @@ message PutRequest {
     }
 
     // Carries the single part of the query stream.
-    oneof ObjectPart {
+    oneof object_part {
       // Carries the initialization parameters of the object stream.
       Init init = 1;
       // Carries part of the object payload.
@@ -237,7 +237,7 @@ message HeadResponse {
       uint64 payload_length = 5;
     }
     // Carries the requested object header or it's part
-    oneof Head{
+    oneof head{
       Header header = 1;
       ShortHeader short_header = 2;
     }

--- a/proto-docs/accounting.md
+++ b/proto-docs/accounting.md
@@ -9,7 +9,9 @@
     
   - Messages
     - [BalanceRequest](#accounting.BalanceRequest)
+    - [BalanceRequest.Body](#accounting.BalanceRequest.Body)
     - [BalanceResponse](#accounting.BalanceResponse)
+    - [BalanceResponse.Body](#accounting.BalanceResponse.Body)
     - [Decimal](#accounting.Decimal)
     
 
@@ -51,10 +53,24 @@ Returns the amount of funds for the requested NeoFS account.
 ### Message BalanceRequest
 Message defines the request body of Balance method.
 
-To indicate the account for which the balance is requested, it's identifier is used.
+To indicate the account for which the balance is requested, it's identifier
+is used.
 
-To gain access to the requested information, the request body must be formed according
-to the requirements from the system specification.
+To gain access to the requested information, the request body must be formed
+according to the requirements from the system specification.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [BalanceRequest.Body](#accounting.BalanceRequest.Body) |  | Body of the balance request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="accounting.BalanceRequest.Body"></a>
+
+### Message BalanceRequest.Body
+
 
 
 | Field | Type | Label | Description |
@@ -68,6 +84,19 @@ to the requirements from the system specification.
 Message defines the response body of Balance method.
 
 The amount of funds is calculated in decimal numbers.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [BalanceResponse.Body](#accounting.BalanceResponse.Body) |  | Body of the balance response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="accounting.BalanceResponse.Body"></a>
+
+### Message BalanceResponse.Body
+
 
 
 | Field | Type | Label | Description |

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -9,17 +9,29 @@
     
   - Messages
     - [DeleteRequest](#container.DeleteRequest)
+    - [DeleteRequest.Body](#container.DeleteRequest.Body)
     - [DeleteResponse](#container.DeleteResponse)
+    - [DeleteResponse.Body](#container.DeleteResponse.Body)
     - [GetExtendedACLRequest](#container.GetExtendedACLRequest)
+    - [GetExtendedACLRequest.Body](#container.GetExtendedACLRequest.Body)
     - [GetExtendedACLResponse](#container.GetExtendedACLResponse)
+    - [GetExtendedACLResponse.Body](#container.GetExtendedACLResponse.Body)
     - [GetRequest](#container.GetRequest)
+    - [GetRequest.Body](#container.GetRequest.Body)
     - [GetResponse](#container.GetResponse)
+    - [GetResponse.Body](#container.GetResponse.Body)
     - [ListRequest](#container.ListRequest)
+    - [ListRequest.Body](#container.ListRequest.Body)
     - [ListResponse](#container.ListResponse)
+    - [ListResponse.Body](#container.ListResponse.Body)
     - [PutRequest](#container.PutRequest)
+    - [PutRequest.Body](#container.PutRequest.Body)
     - [PutResponse](#container.PutResponse)
+    - [PutResponse.Body](#container.PutResponse.Body)
     - [SetExtendedACLRequest](#container.SetExtendedACLRequest)
+    - [SetExtendedACLRequest.Body](#container.SetExtendedACLRequest.Body)
     - [SetExtendedACLResponse](#container.SetExtendedACLResponse)
+    - [SetExtendedACLResponse.Body](#container.SetExtendedACLResponse.Body)
     
 
 - [container/types.proto](#container/types.proto)
@@ -120,6 +132,19 @@ smart-contract storage.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [DeleteRequest.Body](#container.DeleteRequest.Body) |  | Body of container delete request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.DeleteRequest.Body"></a>
+
+### Message DeleteRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | container_id | [refs.ContainerID](#refs.ContainerID) |  | container_id carries identifier of the container to delete from NeoFS. |
 | signature | [bytes](#bytes) |  | Signature of container id according to RFC-6979. |
 
@@ -131,10 +156,36 @@ DeleteResponse is empty because delete operation is asynchronous and done
 via consensus in inner ring nodes
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [DeleteResponse.Body](#container.DeleteResponse.Body) |  | Body of container delete response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.DeleteResponse.Body"></a>
+
+### Message DeleteResponse.Body
+
+
+
 
 <a name="container.GetExtendedACLRequest"></a>
 
 ### Message GetExtendedACLRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [GetExtendedACLRequest.Body](#container.GetExtendedACLRequest.Body) |  | Body of get extended acl request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.GetExtendedACLRequest.Body"></a>
+
+### Message GetExtendedACLRequest.Body
 
 
 
@@ -146,6 +197,19 @@ via consensus in inner ring nodes
 <a name="container.GetExtendedACLResponse"></a>
 
 ### Message GetExtendedACLResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [GetExtendedACLResponse.Body](#container.GetExtendedACLResponse.Body) |  | Body of get extended acl response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.GetExtendedACLResponse.Body"></a>
+
+### Message GetExtendedACLResponse.Body
 
 
 
@@ -163,12 +227,38 @@ via consensus in inner ring nodes
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [GetRequest.Body](#container.GetRequest.Body) |  | Body of container get request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.GetRequest.Body"></a>
+
+### Message GetRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | container_id | [refs.ContainerID](#refs.ContainerID) |  | container_id carries identifier of the container to get. |
 
 
 <a name="container.GetResponse"></a>
 
 ### Message GetResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [GetResponse.Body](#container.GetResponse.Body) |  | Body of container get response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.GetResponse.Body"></a>
+
+### Message GetResponse.Body
 
 
 
@@ -185,6 +275,19 @@ via consensus in inner ring nodes
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [ListRequest.Body](#container.ListRequest.Body) |  | Body of list containers request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.ListRequest.Body"></a>
+
+### Message ListRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | owner_id | [refs.OwnerID](#refs.OwnerID) |  | owner_id carries identifier of the container owner. |
 
 
@@ -196,12 +299,38 @@ via consensus in inner ring nodes
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [ListResponse.Body](#container.ListResponse.Body) |  | Body of list containers response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.ListResponse.Body"></a>
+
+### Message ListResponse.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | container_ids | [refs.ContainerID](#refs.ContainerID) | repeated | ContainerIDs carries list of identifiers of the containers that belong to the owner. |
 
 
 <a name="container.PutRequest"></a>
 
 ### Message PutRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [PutRequest.Body](#container.PutRequest.Body) |  | Body of container put request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.PutRequest.Body"></a>
+
+### Message PutRequest.Body
 
 
 
@@ -220,12 +349,38 @@ via consensus in inner ring nodes
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [PutResponse.Body](#container.PutResponse.Body) |  | Body of container put response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.PutResponse.Body"></a>
+
+### Message PutResponse.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | container_id | [refs.ContainerID](#refs.ContainerID) |  | container_id carries identifier of the new container. |
 
 
 <a name="container.SetExtendedACLRequest"></a>
 
 ### Message SetExtendedACLRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [SetExtendedACLRequest.Body](#container.SetExtendedACLRequest.Body) |  | Body of set extended acl request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.SetExtendedACLRequest.Body"></a>
+
+### Message SetExtendedACLRequest.Body
 
 
 
@@ -238,6 +393,19 @@ via consensus in inner ring nodes
 <a name="container.SetExtendedACLResponse"></a>
 
 ### Message SetExtendedACLResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [SetExtendedACLResponse.Body](#container.SetExtendedACLResponse.Body) |  | Body of set extended acl response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="container.SetExtendedACLResponse.Body"></a>
+
+### Message SetExtendedACLResponse.Body
 
 
 

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -9,36 +9,47 @@
     
   - Messages
     - [DeleteRequest](#object.DeleteRequest)
+    - [DeleteRequest.Body](#object.DeleteRequest.Body)
     - [DeleteResponse](#object.DeleteResponse)
+    - [DeleteResponse.Body](#object.DeleteResponse.Body)
     - [GetRangeHashRequest](#object.GetRangeHashRequest)
+    - [GetRangeHashRequest.Body](#object.GetRangeHashRequest.Body)
     - [GetRangeHashResponse](#object.GetRangeHashResponse)
+    - [GetRangeHashResponse.Body](#object.GetRangeHashResponse.Body)
     - [GetRangeRequest](#object.GetRangeRequest)
+    - [GetRangeRequest.Body](#object.GetRangeRequest.Body)
     - [GetRangeResponse](#object.GetRangeResponse)
+    - [GetRangeResponse.Body](#object.GetRangeResponse.Body)
     - [GetRequest](#object.GetRequest)
+    - [GetRequest.Body](#object.GetRequest.Body)
     - [GetResponse](#object.GetResponse)
+    - [GetResponse.Body](#object.GetResponse.Body)
+    - [GetResponse.Body.Init](#object.GetResponse.Body.Init)
     - [HeadRequest](#object.HeadRequest)
+    - [HeadRequest.Body](#object.HeadRequest.Body)
     - [HeadResponse](#object.HeadResponse)
+    - [HeadResponse.Body](#object.HeadResponse.Body)
+    - [HeadResponse.Body.ShortHeader](#object.HeadResponse.Body.ShortHeader)
     - [PutRequest](#object.PutRequest)
-    - [PutRequest.Init](#object.PutRequest.Init)
+    - [PutRequest.Body](#object.PutRequest.Body)
+    - [PutRequest.Body.Init](#object.PutRequest.Body.Init)
     - [PutResponse](#object.PutResponse)
+    - [PutResponse.Body](#object.PutResponse.Body)
     - [Range](#object.Range)
     - [SearchRequest](#object.SearchRequest)
-    - [SearchRequest.Query](#object.SearchRequest.Query)
-    - [SearchRequest.Query.Filter](#object.SearchRequest.Query.Filter)
+    - [SearchRequest.Body](#object.SearchRequest.Body)
+    - [SearchRequest.Body.Query](#object.SearchRequest.Body.Query)
+    - [SearchRequest.Body.Query.Filter](#object.SearchRequest.Body.Query.Filter)
     - [SearchResponse](#object.SearchResponse)
+    - [SearchResponse.Body](#object.SearchResponse.Body)
     
 
 - [object/types.proto](#object/types.proto)
 
   - Messages
     - [Header](#object.Header)
-    - [Header.Extended](#object.Header.Extended)
-    - [Header.Extended.Attribute](#object.Header.Extended.Attribute)
-    - [Header.Extended.Integrity](#object.Header.Extended.Integrity)
-    - [Header.Extended.Split](#object.Header.Extended.Split)
-    - [Header.Extended.StorageGroup](#object.Header.Extended.StorageGroup)
-    - [Header.Extended.Tombstone](#object.Header.Extended.Tombstone)
-    - [Header.Main](#object.Header.Main)
+    - [Header.Attribute](#object.Header.Attribute)
+    - [Header.Split](#object.Header.Split)
     - [Object](#object.Object)
     
 
@@ -148,10 +159,21 @@ calculated for XORed data.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [refs.Address](#refs.Address) |  | Carries the address of the object to be deleted. |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Carries identifier the object owner. |
+| body | [DeleteRequest.Body](#object.DeleteRequest.Body) |  | Body of delete object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.DeleteRequest.Body"></a>
+
+### Message DeleteRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [refs.Address](#refs.Address) |  | Carries the address of the object to be deleted. |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Carries identifier the object owner. |
 
 
 <a name="object.DeleteResponse"></a>
@@ -159,6 +181,19 @@ calculated for XORed data.
 ### Message DeleteResponse
 DeleteResponse is empty because we cannot guarantee permanent object removal
 in distributed system.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [DeleteResponse.Body](#object.DeleteResponse.Body) |  | Body of delete object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.DeleteResponse.Body"></a>
+
+### Message DeleteResponse.Body
+
 
 
 
@@ -170,16 +205,40 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [GetRangeHashRequest.Body](#object.GetRangeHashRequest.Body) |  | Body of get range hash object request message. |
+| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetRangeHashRequest.Body"></a>
+
+### Message GetRangeHashRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | address | [refs.Address](#refs.Address) |  | Carries address of the object that contains the requested payload range. |
 | ranges | [Range](#object.Range) | repeated | Carries the list of object payload range to calculate homomorphic hash. |
 | salt | [bytes](#bytes) |  | Carries binary salt to XOR object payload ranges before hash calculation. |
-| meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
-| verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
 
 
 <a name="object.GetRangeHashResponse"></a>
 
 ### Message GetRangeHashResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [GetRangeHashResponse.Body](#object.GetRangeHashResponse.Body) |  | Body of get range hash object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetRangeHashResponse.Body"></a>
+
+### Message GetRangeHashResponse.Body
 
 
 
@@ -196,15 +255,39 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [refs.Address](#refs.Address) |  | Address carries address of the object that contains the requested payload range. |
-| range | [Range](#object.Range) |  | Range carries the parameters of the requested payload range. |
+| body | [GetRangeRequest.Body](#object.GetRangeRequest.Body) |  | Body of get range object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetRangeRequest.Body"></a>
+
+### Message GetRangeRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [refs.Address](#refs.Address) |  | Address carries address of the object that contains the requested payload range. |
+| range | [Range](#object.Range) |  | Range carries the parameters of the requested payload range. |
 
 
 <a name="object.GetRangeResponse"></a>
 
 ### Message GetRangeResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [GetRangeResponse.Body](#object.GetRangeResponse.Body) |  | Body of get range object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetRangeResponse.Body"></a>
+
+### Message GetRangeResponse.Body
 
 
 
@@ -221,10 +304,21 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [refs.Address](#refs.Address) |  | Carries the address of the requested object. |
-| raw | [bool](#bool) |  | Carries the raw option flag of the request. Raw request is sent to receive only the objects that are physically stored on the server. |
+| body | [GetRequest.Body](#object.GetRequest.Body) |  | Body of get object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetRequest.Body"></a>
+
+### Message GetRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [refs.Address](#refs.Address) |  | Address of the requested object. |
+| raw | [bool](#bool) |  | Carries the raw option flag of the request. Raw request is sent to receive only the objects that are physically stored on the server. |
 
 
 <a name="object.GetResponse"></a>
@@ -235,8 +329,34 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| header | [Header](#object.Header) |  | Carries the object header. |
-| chunk | [bytes](#bytes) |  | Carries part of the object payload. |
+| body | [GetResponse.Body](#object.GetResponse.Body) |  | Body of get object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.GetResponse.Body"></a>
+
+### Message GetResponse.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| init | [GetResponse.Body.Init](#object.GetResponse.Body.Init) |  | Initialization parameters of the object stream. |
+| chunk | [bytes](#bytes) |  | Part of the object payload. |
+
+
+<a name="object.GetResponse.Body.Init"></a>
+
+### Message GetResponse.Body.Init
+Initialization parameters of the object got from NeoFS.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| object_id | [refs.ObjectID](#refs.ObjectID) |  | Object ID |
+| signature | [service.Signature](#service.Signature) |  | Object signature |
+| header | [Header](#object.Header) |  | Object header. |
 
 
 <a name="object.HeadRequest"></a>
@@ -247,11 +367,22 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [refs.Address](#refs.Address) |  | Carries the address of the object with the requested header. |
-| main_only | [bool](#bool) |  | Carries the option to crop header to main part. |
-| raw | [bool](#bool) |  | Carries the raw option flag of the request. Raw request is sent to receive only the headers of the objects that are physically stored on the server. |
+| body | [HeadRequest.Body](#object.HeadRequest.Body) |  | Body of head object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.HeadRequest.Body"></a>
+
+### Message HeadRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [refs.Address](#refs.Address) |  | Address of the object with the requested header. |
+| main_only | [bool](#bool) |  | Return only minimal header subset |
+| raw | [bool](#bool) |  | Carries the raw option flag of the request. Raw request is sent to receive only the headers of the objects that are physically stored on the server. |
 
 
 <a name="object.HeadResponse"></a>
@@ -262,7 +393,36 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| header | [Header](#object.Header) |  | Carries the requested object header. |
+| body | [HeadResponse.Body](#object.HeadResponse.Body) |  | Body of head object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.HeadResponse.Body"></a>
+
+### Message HeadResponse.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| header | [Header](#object.Header) |  |  |
+| short_header | [HeadResponse.Body.ShortHeader](#object.HeadResponse.Body.ShortHeader) |  |  |
+
+
+<a name="object.HeadResponse.Body.ShortHeader"></a>
+
+### Message HeadResponse.Body.ShortHeader
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| version | [service.Version](#service.Version) |  | Object format version. |
+| creation_epoch | [uint64](#uint64) |  | Epoch when the object was created |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Object's owner |
+| object_type | [ObjectType](#object.ObjectType) |  | Type of the object payload content |
+| payload_length | [uint64](#uint64) |  | Size of payload in bytes. 0xFFFFFFFFFFFFFFFF means `payload_length` is unknown |
 
 
 <a name="object.PutRequest"></a>
@@ -273,27 +433,53 @@ in distributed system.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| init | [PutRequest.Init](#object.PutRequest.Init) |  | Carries the initialization parameters of the object stream. |
-| chunk | [bytes](#bytes) |  | Carries part of the object payload. |
+| body | [PutRequest.Body](#object.PutRequest.Body) |  | Body of put object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
 
 
-<a name="object.PutRequest.Init"></a>
+<a name="object.PutRequest.Body"></a>
 
-### Message PutRequest.Init
+### Message PutRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| init | [PutRequest.Body.Init](#object.PutRequest.Body.Init) |  | Carries the initialization parameters of the object stream. |
+| chunk | [bytes](#bytes) |  | Carries part of the object payload. |
+
+
+<a name="object.PutRequest.Body.Init"></a>
+
+### Message PutRequest.Body.Init
 Groups initialization parameters of object placement in NeoFS.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| header | [Header](#object.Header) |  | Carries the header of the object to save in the system. |
-| copies_number | [uint32](#uint32) |  | Carries the number of the object copies to store within the RPC call. Default zero value is processed according to the container placement rules. |
+| object_id | [refs.ObjectID](#refs.ObjectID) |  | Object ID, where available |
+| signature | [service.Signature](#service.Signature) |  | Object signature, were available |
+| header | [Header](#object.Header) |  | Header of the object to save in the system. |
+| copies_number | [uint32](#uint32) |  | Number of the object copies to store within the RPC call. Default zero value is processed according to the container placement rules. |
 
 
 <a name="object.PutResponse"></a>
 
 ### Message PutResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [PutResponse.Body](#object.PutResponse.Body) |  | Body of put object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.PutResponse.Body"></a>
+
+### Message PutResponse.Body
 
 
 
@@ -322,33 +508,44 @@ Range groups the parameters of object payload range.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| container_id | [refs.ContainerID](#refs.ContainerID) |  | Carries search container identifier. |
-| query | [SearchRequest.Query](#object.SearchRequest.Query) |  |  |
+| body | [SearchRequest.Body](#object.SearchRequest.Body) |  | Body of search object request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
 
 
-<a name="object.SearchRequest.Query"></a>
+<a name="object.SearchRequest.Body"></a>
 
-### Message SearchRequest.Query
+### Message SearchRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| container_id | [refs.ContainerID](#refs.ContainerID) |  | Carries search container identifier. |
+| query | [SearchRequest.Body.Query](#object.SearchRequest.Body.Query) |  |  |
+
+
+<a name="object.SearchRequest.Body.Query"></a>
+
+### Message SearchRequest.Body.Query
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | version | [uint32](#uint32) |  |  |
-| filters | [SearchRequest.Query.Filter](#object.SearchRequest.Query.Filter) | repeated |  |
+| filters | [SearchRequest.Body.Query.Filter](#object.SearchRequest.Body.Query.Filter) | repeated |  |
 
 
-<a name="object.SearchRequest.Query.Filter"></a>
+<a name="object.SearchRequest.Body.Query.Filter"></a>
 
-### Message SearchRequest.Query.Filter
+### Message SearchRequest.Body.Query.Filter
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| match_type | [SearchRequest.Query.Filter.MatchType](#object.SearchRequest.Query.Filter.MatchType) |  |  |
+| match_type | [SearchRequest.Body.Query.Filter.MatchType](#object.SearchRequest.Body.Query.Filter.MatchType) |  |  |
 | name | [string](#string) |  |  |
 | value | [string](#string) |  |  |
 
@@ -361,14 +558,27 @@ Range groups the parameters of object payload range.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| body | [SearchResponse.Body](#object.SearchResponse.Body) |  | Body of search object response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="object.SearchResponse.Body"></a>
+
+### Message SearchResponse.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
 | id_list | [refs.ObjectID](#refs.ObjectID) | repeated | Carries list of object identifiers that match the search query. |
 
  <!-- end messages -->
 
 
-<a name="object.SearchRequest.Query.Filter.MatchType"></a>
+<a name="object.SearchRequest.Body.Query.Filter.MatchType"></a>
 
-### SearchRequest.Query.Filter.MatchType
+### SearchRequest.Body.Query.Filter.MatchType
 
 
 | Name | Number | Description |
@@ -393,117 +603,78 @@ Range groups the parameters of object payload range.
 <a name="object.Header"></a>
 
 ### Message Header
-Header groups the information about the NeoFS object.
 
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| main | [Header.Main](#object.Header.Main) |  | Main carries the main part of the header. Main MUST NOT be NULL. |
-| extended | [Header.Extended](#object.Header.Extended) |  | Extended carries the additional part of the header. |
-
-
-<a name="object.Header.Extended"></a>
-
-### Message Header.Extended
-Extended groups additional information about the object.
-It encapsulates both user and system attributes needed to regulate
-the NeoFS sub-systems.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| integrity | [Header.Extended.Integrity](#object.Header.Extended.Integrity) |  | integrity carries object integrity evidence. |
-| attributes | [Header.Extended.Attribute](#object.Header.Extended.Attribute) | repeated | attributes carries list of the object attributes in a string key-value format. |
-| creation_epoch | [uint64](#uint64) |  | creation_epoch carries number of NeoFS epoch on which the object was created. |
-| tombstone | [Header.Extended.Tombstone](#object.Header.Extended.Tombstone) |  | Tombstone marks the object to be deleted. |
-| homomorphic_hash | [bytes](#bytes) |  | homomorphic_hash carries homomorphic hash of the object payload. |
-| storage_group | [Header.Extended.StorageGroup](#object.Header.Extended.StorageGroup) |  | StorageGroup marks an object containing information about a storage group. |
-| split | [Header.Extended.Split](#object.Header.Extended.Split) |  | Split carries the position of the object in the split hierarchy. |
+| container_id | [refs.ContainerID](#refs.ContainerID) |  | Object's container |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Object's owner |
+| creation_epoch | [uint64](#uint64) |  | Epoch when the object was created |
+| version | [service.Version](#service.Version) |  | Object format version. Effectively the version of API library used to create particular object |
+| payload_length | [uint64](#uint64) |  | Size of payload in bytes. 0xFFFFFFFFFFFFFFFF means `payload_length` is unknown |
+| payload_hash | [bytes](#bytes) |  | Hash of payload bytes |
+| object_type | [ObjectType](#object.ObjectType) |  |  |
+| homomorphic_hash | [bytes](#bytes) |  | Homomorphic hash of the object payload. |
+| session_token | [service.SessionToken](#service.SessionToken) |  | Session token, if it was used during Object creation. Need it to verify integrity and authenticity out of Request scope. |
+| attributes | [Header.Attribute](#object.Header.Attribute) | repeated |  |
+| split | [Header.Split](#object.Header.Split) |  | Position of the object in the split hierarchy. |
 
 
-<a name="object.Header.Extended.Attribute"></a>
+<a name="object.Header.Attribute"></a>
 
-### Message Header.Extended.Attribute
-Attribute groups the parameters of the object attributes.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  | key carries the string key to the object attribute. |
-| value | [string](#string) |  | value carries the string value of the object attribute. |
-
-
-<a name="object.Header.Extended.Integrity"></a>
-
-### Message Header.Extended.Integrity
-Integrity groups evidence of the integrity of an object's structure.
+### Message Header.Attribute
+Attribute groups the user-defined Key-Value pairs attached to the object
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| payload_checksum | [bytes](#bytes) |  | payload_checksum carries the checksum of object payload bytes. Changing any byte of the payload changes the checksum. It is calculated as a SHA-256 hash over payload bytes. |
-| header_checksum | [bytes](#bytes) |  | header_checksum carries checksum of the object header structure. It covers all object attributes. Changing any field of the object except CreatorKey and ChecksumSignature changes the checksum. payload_checksum and header_checksum cannot be merged due to the need to verify the header in the absence of a payload (e.g. in object.Head rpc). It is calculated as a SHA-256 hash over marshaled object header with cut creator_key and checksum_signature. |
-| session_token | [service.SessionToken](#service.SessionToken) |  | session_token carries token of the session within which the object was created. If session token is presented in object, it acts as the user's proof of the correctness of the creator_key. |
-| creator_key | [bytes](#bytes) |  | creator_key carries public key of the object creator in a binary format. |
-| checksum_signature | [bytes](#bytes) |  | checksum_signature carries signature of the structure checksum by the object creator. |
+| key | [string](#string) |  | string key to the object attribute |
+| value | [string](#string) |  | string value of the object attribute |
 
 
-<a name="object.Header.Extended.Split"></a>
+<a name="object.Header.Split"></a>
 
-### Message Header.Extended.Split
-Split groups information about spawning the object through a payload splitting.
+### Message Header.Split
+Information about spawning the objects through a payload splitting.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parent | [refs.ObjectID](#refs.ObjectID) |  | Parent carries identifier of the origin object. |
+| parent | [refs.ObjectID](#refs.ObjectID) |  | Identifier of the origin object. Parent and children objects must be within the same container. Parent object_id is known only to the minor child. |
 | previous | [refs.ObjectID](#refs.ObjectID) |  | Previous carries identifier of the left split neighbor. |
-| next | [refs.ObjectID](#refs.ObjectID) |  | Next carries identifier of the right split neighbor. |
+| parent_signature | [service.Signature](#service.Signature) |  | `signature` field of the parent object. Used to reconstruct parent. |
+| parent_header | [Header](#object.Header) |  | `header` field of the parent object. Used to reconstruct parent. |
 | children | [refs.ObjectID](#refs.ObjectID) | repeated | Children carries list of identifiers of the objects generated by splitting the current. |
-| origin | [Header](#object.Header) |  | Origin carries the header of the origin object. |
-
-
-<a name="object.Header.Extended.StorageGroup"></a>
-
-### Message Header.Extended.StorageGroup
-StorageGroup groups meta information about a storage group.
-
-
-
-<a name="object.Header.Extended.Tombstone"></a>
-
-### Message Header.Extended.Tombstone
-Tombstone groups the options for deleting an object.
-
-
-
-<a name="object.Header.Main"></a>
-
-### Message Header.Main
-Main groups mandatory information about the object.
-Message fields are presented in all NeoFS objects.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| payload_length | [uint64](#uint64) |  | payload_length carries length of the object payload. Each object has a fixed payload length since it's immutable. |
-| address | [refs.Address](#refs.Address) |  | address carries object address in the NeoFS system. It encapsulates the object and the container identifiers. |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | owner_id carries identifier of the object owner. |
 
 
 <a name="object.Object"></a>
 
 ### Message Object
-Object groups the information about the NeoFS object.
-It consists of payload data with additional service information.
+Object structure.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| header | [Header](#object.Header) |  | Header carries the object header. |
-| payload | [bytes](#bytes) |  | Payload carries the object payload bytes. |
+| object_id | [refs.ObjectID](#refs.ObjectID) |  | Object's unique identifier. Object is content-addressed. It means id will change if header or payload changes. It's calculated as a hash of header field, which contains hash of object's payload |
+| signature | [service.Signature](#service.Signature) |  | Signed object_id |
+| header | [Header](#object.Header) |  | Object metadata headers |
+| payload | [bytes](#bytes) |  | Payload bytes. |
 
  <!-- end messages -->
+
+
+<a name="object.ObjectType"></a>
+
+### ObjectType
+Type of the object payload content
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| REGULAR | 0 | Just a normal object |
+| TOMBSTONE | 1 | Used internally to identify deleted objects |
+| STORAGE_GROUP | 2 | Identifies that the object holds StorageGroup information |
+
 
  <!-- end enums -->
 

--- a/proto-docs/service.md
+++ b/proto-docs/service.md
@@ -6,21 +6,23 @@
 - [service/meta.proto](#service/meta.proto)
 
   - Messages
+    - [BearerToken](#service.BearerToken)
+    - [BearerToken.Body](#service.BearerToken.Body)
     - [RequestMetaHeader](#service.RequestMetaHeader)
-    - [RequestMetaHeader.XHeader](#service.RequestMetaHeader.XHeader)
+    - [ResponseMetaHeader](#service.ResponseMetaHeader)
+    - [SessionToken](#service.SessionToken)
+    - [SessionToken.Body](#service.SessionToken.Body)
+    - [TokenLifetime](#service.TokenLifetime)
     - [Version](#service.Version)
+    - [XHeader](#service.XHeader)
     
 
 - [service/verify.proto](#service/verify.proto)
 
   - Messages
-    - [BearerTokenMsg](#service.BearerTokenMsg)
-    - [BearerTokenMsg.Info](#service.BearerTokenMsg.Info)
     - [RequestVerificationHeader](#service.RequestVerificationHeader)
-    - [SessionToken](#service.SessionToken)
-    - [SessionToken.Info](#service.SessionToken.Info)
+    - [ResponseVerificationHeader](#service.ResponseVerificationHeader)
     - [Signature](#service.Signature)
-    - [TokenLifetime](#service.TokenLifetime)
     
 
 - [Scalar Value Types](#scalar-value-types)
@@ -36,28 +38,102 @@
  <!-- end services -->
 
 
+<a name="service.BearerToken"></a>
+
+### Message BearerToken
+BearerToken has information about request ACL rules with limited lifetime
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [BearerToken.Body](#service.BearerToken.Body) |  | Bearer Token body |
+| signature | [Signature](#service.Signature) |  | Signature of BearerToken body |
+
+
+<a name="service.BearerToken.Body"></a>
+
+### Message BearerToken.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| eacl_table | [acl.EACLTable](#acl.EACLTable) |  | EACLTable carries table of extended ACL rules |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the token owner |
+| lifetime | [TokenLifetime](#service.TokenLifetime) |  | Token expiration and valid time period parameters |
+
+
 <a name="service.RequestMetaHeader"></a>
 
 ### Message RequestMetaHeader
-RequestMetaHeader contains information about request meta headers.
+Information about the request
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| ttl | [uint32](#uint32) |  | Carries maximum number of nodes in the request route. |
-| x_headers | [RequestMetaHeader.XHeader](#service.RequestMetaHeader.XHeader) | repeated | Carries request X-Headers. |
+| version | [Version](#service.Version) |  | Client API version. |
+| epoch | [uint64](#uint64) |  | Client local epoch number. Set to 0 if unknown. |
+| ttl | [uint32](#uint32) |  | Maximum number of nodes in the request route. |
+| x_headers | [XHeader](#service.XHeader) | repeated | Request X-Headers. |
+| token | [SessionToken](#service.SessionToken) |  | Token is a token of the session within which the request is sent |
+| bearer | [BearerToken](#service.BearerToken) |  | Bearer is a Bearer token of the request |
+| origin | [RequestMetaHeader](#service.RequestMetaHeader) |  | RequestMetaHeader of the origin request. |
 
 
-<a name="service.RequestMetaHeader.XHeader"></a>
+<a name="service.ResponseMetaHeader"></a>
 
-### Message RequestMetaHeader.XHeader
+### Message ResponseMetaHeader
+Information about the response
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| version | [Version](#service.Version) |  | Server API version. |
+| epoch | [uint64](#uint64) |  | Server local epoch number. |
+| ttl | [uint32](#uint32) |  | Maximum number of nodes in the response route. |
+| x_headers | [XHeader](#service.XHeader) | repeated | Response X-Headers. |
+| origin | [ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta header of the origin response. |
+
+
+<a name="service.SessionToken"></a>
+
+### Message SessionToken
+NeoFS session token.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [SessionToken.Body](#service.SessionToken.Body) |  | Session Token body |
+| signature | [Signature](#service.Signature) |  | Signature is a signature of session token information |
+
+
+<a name="service.SessionToken.Body"></a>
+
+### Message SessionToken.Body
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  | Carries key to the X-Header. |
-| value | [string](#string) |  | Carries value of the X-Header. |
+| id | [bytes](#bytes) |  | ID is a token identifier. valid UUIDv4 represented in bytes |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the session initiator. |
+| verb | [SessionToken.Body.Verb](#service.SessionToken.Body.Verb) |  | Verb is a type of request for which the token is issued |
+| lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
+| session_key | [bytes](#bytes) |  | SessionKey is a public key of session key |
+| object_address | [refs.Address](#refs.Address) |  | object_address represents the object session context. |
+
+
+<a name="service.TokenLifetime"></a>
+
+### Message TokenLifetime
+Lifetime parameters of the token. Filed names taken from rfc7519.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| exp | [uint64](#uint64) |  | Expiration Epoch |
+| nbf | [uint64](#uint64) |  | Not valid before Epoch |
+| iat | [uint64](#uint64) |  | Issued at Epoch |
 
 
 <a name="service.Version"></a>
@@ -71,7 +147,36 @@ Represents API version used by node.
 | major | [uint32](#uint32) |  | Major API version. |
 | minor | [uint32](#uint32) |  | Minor API version. |
 
+
+<a name="service.XHeader"></a>
+
+### Message XHeader
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  | Key of the X-Header. |
+| value | [string](#string) |  | Value of the X-Header. |
+
  <!-- end messages -->
+
+
+<a name="service.SessionToken.Body.Verb"></a>
+
+### SessionToken.Body.Verb
+Verb is an enumeration of session request types
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| OBJECT_PUT | 0 | Refers to object.Put RPC call |
+| OBJECT_GET | 1 | Refers to object.Get RPC call |
+| OBJECT_HEAD | 2 | Refers to object.Head RPC call |
+| OBJECT_SEARCH | 3 | Refers to object.Search RPC call |
+| OBJECT_DELETE | 4 | Refers to object.Delete RPC call |
+| OBJECT_RANGE | 5 | Refers to object.GetRange RPC call |
+| OBJECT_RANGEHASH | 6 | Refers to object.GetRangeHash RPC call |
+
 
  <!-- end enums -->
 
@@ -86,79 +191,38 @@ Represents API version used by node.
  <!-- end services -->
 
 
-<a name="service.BearerTokenMsg"></a>
-
-### Message BearerTokenMsg
-BearerTokenMsg carries information about request ACL rules with limited lifetime
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| token_info | [BearerTokenMsg.Info](#service.BearerTokenMsg.Info) |  | token_info is a grouped information about token |
-| owner_key | [bytes](#bytes) |  | owner_key is a public key of the token owner |
-| signature | [bytes](#bytes) |  | Signature is a signature of token information |
-
-
-<a name="service.BearerTokenMsg.Info"></a>
-
-### Message BearerTokenMsg.Info
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| eacl_table | [acl.EACLTable](#acl.EACLTable) |  | EACLTable carries table of extended ACL rules. |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the token owner. |
-| valid_until | [uint64](#uint64) |  | ValidUntil carries a last epoch of token lifetime |
-
-
 <a name="service.RequestVerificationHeader"></a>
 
 ### Message RequestVerificationHeader
-RequestVerificationHeader is a set of signatures of every NeoFS Node that
-processed request.
+Verification info for request signed by all intermediate nodes
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| signatures | [Signature](#service.Signature) | repeated | Signatures is a set of signatures of every passed NeoFS Node |
-| token | [SessionToken](#service.SessionToken) |  | Token is a token of the session within which the request is sent |
-| bearer | [BearerTokenMsg](#service.BearerTokenMsg) |  | Bearer is a Bearer token of the request |
+| body_signature | [Signature](#service.Signature) |  | Request Body signature. Should be generated once by request initiator. |
+| meta_signature | [Signature](#service.Signature) |  | Request Meta signature is added and signed by any intermediate node |
+| origin_signature | [Signature](#service.Signature) |  | Sign previous hops |
+| origin | [RequestVerificationHeader](#service.RequestVerificationHeader) |  | Chain of previous hops signatures |
 
 
-<a name="service.SessionToken"></a>
+<a name="service.ResponseVerificationHeader"></a>
 
-### Message SessionToken
-Represents the NeoFS session token.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| token_info | [SessionToken.Info](#service.SessionToken.Info) |  | token_info is a grouped information about token |
-| signature | [bytes](#bytes) |  | Signature is a signature of session token information |
-
-
-<a name="service.SessionToken.Info"></a>
-
-### Message SessionToken.Info
-
+### Message ResponseVerificationHeader
+Verification info for response signed by all intermediate nodes
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [bytes](#bytes) |  | ID is a token identifier. valid UUIDv4 represented in bytes |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | OwnerID carries identifier of the session initiator. |
-| verb | [SessionToken.Info.Verb](#service.SessionToken.Info.Verb) |  | Verb is a type of request for which the token is issued |
-| lifetime | [TokenLifetime](#service.TokenLifetime) |  | Lifetime is a lifetime of the session |
-| session_key | [bytes](#bytes) |  | SessionKey is a public key of session key |
-| owner_key | [bytes](#bytes) |  | OwnerKey is a public key of the token owner |
-| object_address | [refs.Address](#refs.Address) |  | object_address represents the object session context. |
+| body_signature | [Signature](#service.Signature) |  | Response Body signature. Should be generated once by answering node. |
+| meta_signature | [Signature](#service.Signature) |  | Response Meta signature is added and signed by any intermediate node |
+| origin_signature | [Signature](#service.Signature) |  | Sign previous hops |
+| origin | [ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Chain of previous hops signatures |
 
 
 <a name="service.Signature"></a>
 
 ### Message Signature
-
+Signature of something in NeoFS
 
 
 | Field | Type | Label | Description |
@@ -166,36 +230,7 @@ Represents the NeoFS session token.
 | key | [bytes](#bytes) |  | Public key used for signing. |
 | sign | [bytes](#bytes) |  | Signature |
 
-
-<a name="service.TokenLifetime"></a>
-
-### Message TokenLifetime
-TokenLifetime carries a group of lifetime parameters of the token
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| created | [uint64](#uint64) |  | created carries an initial epoch of token lifetime |
-| valid_until | [uint64](#uint64) |  | valid_until carries a last epoch of token lifetime |
-
  <!-- end messages -->
-
-
-<a name="service.SessionToken.Info.Verb"></a>
-
-### SessionToken.Info.Verb
-Verb is an enumeration of session request types
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| OBJECT_PUT | 0 | Refers to object.Put RPC call |
-| OBJECT_GET | 1 | Refers to object.Get RPC call |
-| OBJECT_HEAD | 2 | Refers to object.Head RPC call |
-| OBJECT_SEARCH | 3 | Refers to object.Search RPC call |
-| OBJECT_DELETE | 4 | Refers to object.Delete RPC call |
-| OBJECT_RANGE | 5 | Refers to object.GetRange RPC call |
-| OBJECT_RANGEHASH | 6 | Refers to object.GetRangeHash RPC call |
-
 
  <!-- end enums -->
 

--- a/proto-docs/session.md
+++ b/proto-docs/session.md
@@ -9,7 +9,9 @@
     
   - Messages
     - [CreateRequest](#session.CreateRequest)
+    - [CreateRequest.Body](#session.CreateRequest.Body)
     - [CreateResponse](#session.CreateResponse)
+    - [CreateResponse.Body](#session.CreateResponse.Body)
     
 
 - [Scalar Value Types](#scalar-value-types)
@@ -52,16 +54,40 @@ CreateRequest carries an information necessary for opening a session.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Carries an identifier of a session initiator. |
-| lifetime | [service.TokenLifetime](#service.TokenLifetime) |  | Carries a lifetime of the session. |
+| body | [CreateRequest.Body](#session.CreateRequest.Body) |  | Body of create session token request message. |
 | meta_header | [service.RequestMetaHeader](#service.RequestMetaHeader) |  | Carries request meta information. Header data is used only to regulate message transport and does not affect request execution. |
 | verify_header | [service.RequestVerificationHeader](#service.RequestVerificationHeader) |  | Carries request verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="session.CreateRequest.Body"></a>
+
+### Message CreateRequest.Body
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| owner_id | [refs.OwnerID](#refs.OwnerID) |  | Carries an identifier of a session initiator. |
+| lifetime | [service.TokenLifetime](#service.TokenLifetime) |  | Carries a lifetime of the session. |
 
 
 <a name="session.CreateResponse"></a>
 
 ### Message CreateResponse
 CreateResponse carries an information about the opened session.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| body | [CreateResponse.Body](#session.CreateResponse.Body) |  | Body of create session token response message. |
+| meta_header | [service.ResponseMetaHeader](#service.ResponseMetaHeader) |  | Carries response meta information. Header data is used only to regulate message transport and does not affect request execution. |
+| verify_header | [service.ResponseVerificationHeader](#service.ResponseVerificationHeader) |  | Carries response verification information. This header is used to authenticate the nodes of the message route and check the correctness of transmission. |
+
+
+<a name="session.CreateResponse.Body"></a>
+
+### Message CreateResponse.Body
+
 
 
 | Field | Type | Label | Description |

--- a/service/meta.proto
+++ b/service/meta.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/nspcc-dev/neofs-api-go/service";
 option csharp_namespace = "NeoFS.API.Service";
 
 import "acl/types.proto";
+import "refs/types.proto";
 import "service/verify.proto";
 
 message XHeader {
@@ -23,6 +24,76 @@ message Version {
   uint32 minor = 2;
 }
 
+// Lifetime parameters of the token. Filed names taken from rfc7519.
+message TokenLifetime {
+  // Expiration Epoch
+  uint64 exp = 1;
+  // Not valid before Epoch
+  uint64 nbf = 2;
+  // Issued at Epoch
+  uint64 iat = 3;
+}
+
+// NeoFS session token.
+message SessionToken {
+  message Body {
+    // ID is a token identifier. valid UUIDv4 represented in bytes
+    bytes id = 1;
+    // OwnerID carries identifier of the session initiator.
+    refs.OwnerID owner_id = 2;
+    // Verb is an enumeration of session request types
+    enum Verb {
+      // Refers to object.Put RPC call
+      OBJECT_PUT = 0;
+      // Refers to object.Get RPC call
+      OBJECT_GET = 1;
+      // Refers to object.Head RPC call
+      OBJECT_HEAD = 2;
+      // Refers to object.Search RPC call
+      OBJECT_SEARCH = 3;
+      // Refers to object.Delete RPC call
+      OBJECT_DELETE = 4;
+      // Refers to object.GetRange RPC call
+      OBJECT_RANGE = 5;
+      // Refers to object.GetRangeHash RPC call
+      OBJECT_RANGEHASH = 6;
+    }
+    // Verb is a type of request for which the token is issued
+    Verb verb = 3;
+    // Lifetime is a lifetime of the session
+    TokenLifetime lifetime = 4;
+    // SessionKey is a public key of session key
+    bytes session_key = 5;
+    // Carries context of the session.
+    oneof context {
+      // object_address represents the object session context.
+      refs.Address object_address = 6;
+    }
+  }
+  // Session Token body
+  Body token = 1;
+
+  // Signature is a signature of session token information
+  Signature signature = 2;
+}
+
+// BearerToken has information about request ACL rules with limited lifetime
+message BearerToken {
+  message Body {
+    // EACLTable carries table of extended ACL rules
+    acl.EACLTable eacl_table = 1;
+    // OwnerID carries identifier of the token owner
+    refs.OwnerID owner_id = 2;
+    // Token expiration and valid time period parameters
+    TokenLifetime lifetime = 3;
+  }
+  // Bearer Token body
+  Body token = 1;
+
+  // Signature of BearerToken body
+  Signature signature = 2;
+}
+
 // Information about the request
 message RequestMetaHeader {
   // Client API version.
@@ -33,9 +104,13 @@ message RequestMetaHeader {
   uint32 ttl = 3;
   // Request X-Headers.
   repeated XHeader x_headers = 4;
+  // Token is a token of the session within which the request is sent
+  SessionToken token = 5;
+  // Bearer is a Bearer token of the request
+  BearerToken bearer = 6;
 
   // RequestMetaHeader of the origin request.
-  RequestMetaHeader origin = 98;
+  RequestMetaHeader origin = 7;
 }
 
 // Information about the response
@@ -50,5 +125,5 @@ message ResponseMetaHeader {
   repeated XHeader x_headers = 4;
 
   // Carries response meta header of the origin response.
-  ResponseMetaHeader origin = 98;
+  ResponseMetaHeader origin = 5;
 }

--- a/service/meta.proto
+++ b/service/meta.proto
@@ -5,6 +5,16 @@ package service;
 option go_package = "github.com/nspcc-dev/neofs-api-go/service";
 option csharp_namespace = "NeoFS.API.Service";
 
+import "acl/types.proto";
+import "service/verify.proto";
+
+message XHeader {
+  // Key of the X-Header.
+  string key = 1;
+  // Value of the X-Header.
+  string value = 2;
+}
+
 // Represents API version used by node.
 message Version {
   // Major API version.
@@ -13,19 +23,32 @@ message Version {
   uint32 minor = 2;
 }
 
-// RequestMetaHeader contains information about request meta headers.
+// Information about the request
 message RequestMetaHeader {
-  // Carries maximum number of nodes in the request route.
-  uint32 ttl = 1;
+  // Client API version.
+  Version version = 1;
+  // Client local epoch number. Set to 0 if unknown.
+  uint64 epoch = 2;
+  // Maximum number of nodes in the request route.
+  uint32 ttl = 3;
+  // Request X-Headers.
+  repeated XHeader x_headers = 4;
 
-  message XHeader {
-    // Carries key to the X-Header.
-    string key = 1;
+  // RequestMetaHeader of the origin request.
+  RequestMetaHeader origin = 98;
+}
 
-    // Carries value of the X-Header.
-    string value = 2;
-  }
+// Information about the response
+message ResponseMetaHeader {
+  // Server API version.
+  Version version = 1;
+  // Server local epoch number.
+  uint64 epoch = 2;
+  // Maximum number of nodes in the response route.
+  uint32 ttl = 3;
+  // Response X-Headers.
+  repeated XHeader x_headers = 4;
 
-  // Carries request X-Headers.
-  repeated XHeader x_headers = 2;
+  // Carries response meta header of the origin response.
+  ResponseMetaHeader origin = 98;
 }

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -8,6 +8,7 @@ option csharp_namespace = "NeoFS.API.Service";
 import "acl/types.proto";
 import "refs/types.proto";
 
+// Signature of something in NeoFS
 message Signature {
   // Public key used for signing.
   bytes key = 1;
@@ -17,106 +18,26 @@ message Signature {
 
 // Verification info for request signed by all intermediate nodes
 message RequestVerificationHeader {
+  // Request Body signature. Should be generated once by request initiator.
   Signature body_signature = 1;
+  // Request Meta signature is added and signed by any intermediate node
   Signature meta_signature = 2;
+  // Sign previous hops
+  Signature origin_signature = 3;
 
-  // Token is a token of the session within which the request is sent
-  SessionToken token = 3;
-  // Bearer is a Bearer token of the request
-  BearerTokenMsg bearer = 4;
-
-  RequestVerificationHeader origin = 5;
-}
-
-// Represents the NeoFS session token.
-message SessionToken {
-  message Info {
-    // ID is a token identifier. valid UUIDv4 represented in bytes
-    bytes id = 1;
-
-    // OwnerID carries identifier of the session initiator.
-    refs.OwnerID owner_id = 2;
-
-    // Verb is an enumeration of session request types
-    enum Verb {
-      // Refers to object.Put RPC call
-      OBJECT_PUT = 0;
-      // Refers to object.Get RPC call
-      OBJECT_GET = 1;
-      // Refers to object.Head RPC call
-      OBJECT_HEAD = 2;
-      // Refers to object.Search RPC call
-      OBJECT_SEARCH = 3;
-      // Refers to object.Delete RPC call
-      OBJECT_DELETE = 4;
-      // Refers to object.GetRange RPC call
-      OBJECT_RANGE = 5;
-      // Refers to object.GetRangeHash RPC call
-      OBJECT_RANGEHASH = 6;
-    }
-
-    // Verb is a type of request for which the token is issued
-    Verb verb = 3;
-
-    // Lifetime is a lifetime of the session
-    TokenLifetime lifetime = 4;
-
-    // SessionKey is a public key of session key
-    bytes session_key = 5;
-
-    // OwnerKey is a public key of the token owner
-    bytes owner_key = 6;
-
-    // Carries context of the session.
-    oneof context {
-      // object_address represents the object session context.
-      refs.Address object_address = 7;
-    }
-  }
-
-  // token_info is a grouped information about token
-  Info token_info = 1;
-
-  // Signature is a signature of session token information
-  bytes signature = 2;
-}
-
-// TokenLifetime carries a group of lifetime parameters of the token
-message TokenLifetime {
-  // created carries an initial epoch of token lifetime
-  uint64 created = 1;
-
-  // valid_until carries a last epoch of token lifetime
-  uint64 valid_until = 2;
-}
-
-// BearerTokenMsg carries information about request ACL rules with limited lifetime
-message BearerTokenMsg {
-  message Info {
-    // EACLTable carries table of extended ACL rules.
-    acl.EACLTable eacl_table = 1;
-
-    // OwnerID carries identifier of the token owner.
-    refs.OwnerID owner_id = 2;
-
-    // ValidUntil carries a last epoch of token lifetime
-    uint64 valid_until = 3;
-  }
-
-  // token_info is a grouped information about token
-  Info token_info = 1;
-
-  // owner_key is a public key of the token owner
-  bytes owner_key = 2;
-
-  // Signature is a signature of token information
-  bytes signature = 3;
+  // Chain of previous hops signatures
+  RequestVerificationHeader origin = 4;
 }
 
 // Verification info for response signed by all intermediate nodes
 message ResponseVerificationHeader {
+  // Response Body signature. Should be generated once by answering node.
   Signature body_signature = 1;
+  // Response Meta signature is added and signed by any intermediate node
   Signature meta_signature = 2;
+  // Sign previous hops
+  Signature origin_signature = 3;
 
-  ResponseVerificationHeader origin = 3;
+  // Chain of previous hops signatures
+  ResponseVerificationHeader origin = 4;
 }

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -15,17 +15,17 @@ message Signature {
   bytes sign = 2;
 }
 
-// RequestVerificationHeader is a set of signatures of every NeoFS Node that
-// processed request.
+// Verification info for request signed by all intermediate nodes
 message RequestVerificationHeader {
-  // Signatures is a set of signatures of every passed NeoFS Node
-  repeated Signature signatures = 1;
+  Signature body_signature = 1;
+  Signature meta_signature = 2;
 
   // Token is a token of the session within which the request is sent
-  SessionToken token = 2;
-
+  SessionToken token = 3;
   // Bearer is a Bearer token of the request
-  BearerTokenMsg bearer = 3;
+  BearerTokenMsg bearer = 4;
+
+  RequestVerificationHeader origin = 5;
 }
 
 // Represents the NeoFS session token.
@@ -111,4 +111,12 @@ message BearerTokenMsg {
 
   // Signature is a signature of token information
   bytes signature = 3;
+}
+
+// Verification info for response signed by all intermediate nodes
+message ResponseVerificationHeader {
+  Signature body_signature = 1;
+  Signature meta_signature = 2;
+
+  ResponseVerificationHeader origin = 3;
 }


### PR DESCRIPTION
For the cases when we need to relay a request between several nodes, we need to have a mechanism to record message path in a verifiable manner. The proposed solution is to recursively add signed request/response meta information on each hop.