### PR TITLE
Add grpc suffix to go_package option

### DIFF
--- a/accounting/service.proto
+++ b/accounting/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.accounting;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/accounting;accounting";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/accounting/grpc;accounting";
 option csharp_namespace = "NeoFS.API.v2.Accounting";
 
 import "refs/types.proto";

--- a/acl/types.proto
+++ b/acl/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.acl;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/acl;acl";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc;acl";
 option csharp_namespace = "NeoFS.API.v2.Acl";
 
 import "refs/types.proto";

--- a/container/service.proto
+++ b/container/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.container;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/container;container";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/container/grpc;container";
 option csharp_namespace = "NeoFS.API.v2.Container";
 
 import "acl/types.proto";

--- a/container/types.proto
+++ b/container/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.container;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/container;container";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/container/grpc;container";
 option csharp_namespace = "NeoFS.API.v2.Container";
 
 import "netmap/types.proto";

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.netmap;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/netmap;netmap";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc;netmap";
 option csharp_namespace = "NeoFS.API.v2.Netmap";
 
 // Set of rules to select a subset of nodes able to store container's objects

--- a/object/service.proto
+++ b/object/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.object;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/object;object";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/object/grpc;object";
 option csharp_namespace = "NeoFS.API.v2.Object";
 
 import "object/types.proto";

--- a/object/types.proto
+++ b/object/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.object;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/object;object";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/object/grpc;object";
 option csharp_namespace = "NeoFS.API.v2.Object";
 
 import "refs/types.proto";

--- a/refs/types.proto
+++ b/refs/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.refs;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/refs;refs";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc;refs";
 option csharp_namespace = "NeoFS.API.v2.Refs";
 
 // Address of object (container id + object id)

--- a/service/meta.proto
+++ b/service/meta.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.service;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/service;service";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/service/grpc;service";
 option csharp_namespace = "NeoFS.API.v2.Service";
 
 import "acl/types.proto";

--- a/service/verify.proto
+++ b/service/verify.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.service;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/service;service";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/service/grpc;service";
 option csharp_namespace = "NeoFS.API.v2.Service";
 
 import "acl/types.proto";

--- a/session/service.proto
+++ b/session/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.session;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/session;session";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/session/grpc;session";
 option csharp_namespace = "NeoFS.API.v2.Session";
 
 import "refs/types.proto";

--- a/storagegroup/types.proto
+++ b/storagegroup/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package neo.fs.v2.storagegroup;
 
-option go_package = "github.com/nspcc-dev/neofs-api-go/v2/storagegroup;storagegroup";
+option go_package = "github.com/nspcc-dev/neofs-api-go/v2/storagegroup/grpc;storagegroup";
 option csharp_namespace = "NeoFS.API.v2.StorageGroup";
 
 import "refs/types.proto";


### PR DESCRIPTION
To simplify adding more transport level protocols to `neofs-api-go` in future, we need to separate currently default gRPC.