### PR TITLE
Add version fields where it makes sense

### DIFF
--- a/container/types.proto
+++ b/container/types.proto
@@ -7,21 +7,26 @@ option csharp_namespace = "NeoFS.API.v2.Container";
 
 import "netmap/types.proto";
 import "refs/types.proto";
+import "service/meta.proto";
 
 // Container is a structure that defines object placement behaviour. Objects
 // can be stored only within containers. They define placement rule, attributes
 // and access control information. ID of the container is a 32 byte long
 // SHA256 hash of stable-marshalled container message.
 message Container {
+  // Container format version.
+  // Effectively the version of API library used to create container
+  neo.fs.v2.service.Version version = 1;
+
   // OwnerID carries identifier of the container owner.
-  neo.fs.v2.refs.OwnerID owner_id = 1;
+  neo.fs.v2.refs.OwnerID owner_id = 2;
 
   // Nonce is a 16 byte UUID, used to avoid collisions of container id.
-  bytes nonce = 2;
+  bytes nonce = 3;
 
   // BasicACL contains access control rules for owner, system, others groups and
   // permission bits for bearer token and Extended ACL.
-  uint32 basic_acl = 3;
+  uint32 basic_acl = 4;
 
   // Attribute is a key-value pair of strings.
   message Attribute {
@@ -32,8 +37,8 @@ message Container {
     string value = 2;
   }
   // Attributes define any immutable characteristics of container.
-  repeated Attribute attributes = 4;
+  repeated Attribute attributes = 5;
 
   // Placement policy for the object inside the container.
-  neo.fs.v2.netmap.PlacementPolicy placement_policy = 5;
+  neo.fs.v2.netmap.PlacementPolicy placement_policy = 6;
 }

--- a/object/types.proto
+++ b/object/types.proto
@@ -23,18 +23,18 @@ enum ObjectType {
 
 // Object Headers
 message Header {
-  // Object's container
-  neo.fs.v2.refs.ContainerID container_id = 1;
-
-  // Object's owner
-  neo.fs.v2.refs.OwnerID owner_id = 2;
-
-  // Epoch when the object was created
-  uint64 creation_epoch = 3;
-
   // Object format version.
   // Effectively the version of API library used to create particular object
-  neo.fs.v2.service.Version version = 4;
+  neo.fs.v2.service.Version version = 1;
+
+  // Object's container
+  neo.fs.v2.refs.ContainerID container_id = 2;
+
+  // Object's owner
+  neo.fs.v2.refs.OwnerID owner_id = 3;
+
+  // Object creation Epoch
+  uint64 creation_epoch = 4;
 
   // Size of payload in bytes.
   // 0xFFFFFFFFFFFFFFFF means `payload_length` is unknown

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -435,6 +435,7 @@ SHA256 hash of stable-marshalled container message.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| version | [neo.fs.v2.service.Version](#neo.fs.v2.service.Version) |  | Container format version. Effectively the version of API library used to create container |
 | owner_id | [neo.fs.v2.refs.OwnerID](#neo.fs.v2.refs.OwnerID) |  | OwnerID carries identifier of the container owner. |
 | nonce | [bytes](#bytes) |  | Nonce is a 16 byte UUID, used to avoid collisions of container id. |
 | basic_acl | [uint32](#uint32) |  | BasicACL contains access control rules for owner, system, others groups and permission bits for bearer token and Extended ACL. |

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -596,10 +596,10 @@ Object Headers
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| version | [neo.fs.v2.service.Version](#neo.fs.v2.service.Version) |  | Object format version. Effectively the version of API library used to create particular object |
 | container_id | [neo.fs.v2.refs.ContainerID](#neo.fs.v2.refs.ContainerID) |  | Object's container |
 | owner_id | [neo.fs.v2.refs.OwnerID](#neo.fs.v2.refs.OwnerID) |  | Object's owner |
-| creation_epoch | [uint64](#uint64) |  | Epoch when the object was created |
-| version | [neo.fs.v2.service.Version](#neo.fs.v2.service.Version) |  | Object format version. Effectively the version of API library used to create particular object |
+| creation_epoch | [uint64](#uint64) |  | Object creation Epoch |
 | payload_length | [uint64](#uint64) |  | Size of payload in bytes. 0xFFFFFFFFFFFFFFFF means `payload_length` is unknown |
 | payload_hash | [bytes](#bytes) |  | Hash of payload bytes |
 | object_type | [ObjectType](#neo.fs.v2.object.ObjectType) |  | Special object type |


### PR DESCRIPTION
Some pieces of data (container, object, etc) may be stored for a long time and
there will be a need in the future to understand which obscure format from the
past was used to create it.