### PR TITLE
Add separate checksum type

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -385,6 +385,9 @@ message GetRangeHashRequest {
 
     // Carries binary salt to XOR object payload ranges before hash calculation.
     bytes salt = 3;
+
+    // Checksum algorithm type
+    neo.fs.v2.refs.ChecksumType type = 4;
   }
   // Body of get range hash object request message.
   Body body = 1;
@@ -402,8 +405,11 @@ message GetRangeHashRequest {
 message GetRangeHashResponse {
   // Response body
   message Body {
-    // Carries list of homomorphic hashes in a binary format.
-    repeated bytes hash_list = 1;
+    // Checksum algorithm type
+    neo.fs.v2.refs.ChecksumType type = 1;
+
+    // List of range hashes in a binary format.
+    repeated bytes hash_list = 2;
   }
   // Body of get range hash object response message.
   Body body = 1;

--- a/object/types.proto
+++ b/object/types.proto
@@ -67,13 +67,13 @@ message Header {
   uint64 payload_length = 5;
 
   // Hash of payload bytes
-  bytes payload_hash = 6;
+  Checksum payload_hash = 6;
 
   // Special object type
   ObjectType object_type = 7;
 
   // Homomorphic hash of the object payload.
-  bytes homomorphic_hash = 8;
+  Checksum homomorphic_hash = 8;
 
   // Session token, if it was used during Object creation.
   // Need it to verify integrity and authenticity out of Request scope.

--- a/refs/types.proto
+++ b/refs/types.proto
@@ -47,3 +47,21 @@ message Signature {
   // Signature
   bytes sign = 2;
 }
+
+// Checksum algorithm type
+enum ChecksumType {
+  // Unknown. Not used
+  CHECKSUM_TYPE_UNSPECIFIED = 0;
+
+  // Tillich-Zemor homomorphic hash funciton
+  TZ = 1;
+
+  // SHA-256
+  SHA256 = 2;
+}
+
+// Checksum message
+message Checksum {
+  ChecksumType type = 1;
+  bytes sum = 2;
+}

--- a/storagegroup/types.proto
+++ b/storagegroup/types.proto
@@ -18,7 +18,7 @@ message StorageGroup {
   // payloads of the storage group members
   // The order of concatenation is the same as the order of the members in the
   // Members field.
-  bytes validation_hash = 2;
+  Checksum validation_hash = 2;
 
   // expiration_epoch carries last NeoFS epoch number of the storage group
   // lifetime.


### PR DESCRIPTION
NeoFS uses different checksum algorithms. It looks like we need to explicitly define what algorithm is used in each particular case.