### PR TITLE
Put NodeInfo public_key field first

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -92,11 +92,11 @@ message PlacementPolicy {
 
 // NeoFS node description
 message NodeInfo {
-  // Ways to connect to a node
-  string address = 1;
-
   // Public key of the NeoFS node in a binary format.
-  bytes public_key = 2;
+  bytes public_key = 1;
+
+  // Ways to connect to a node
+  string address = 2;
 
   // Attributes of the NeoFS node.
   message Attribute {

--- a/proto-docs/netmap.md
+++ b/proto-docs/netmap.md
@@ -37,8 +37,8 @@ NeoFS node description
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [string](#string) |  | Ways to connect to a node |
 | public_key | [bytes](#bytes) |  | Public key of the NeoFS node in a binary format. |
+| address | [string](#string) |  | Ways to connect to a node |
 | attributes | [NodeInfo.Attribute](#neo.fs.v2.netmap.NodeInfo.Attribute) | repeated | Carries list of the NeoFS node attributes in a string key-value format. |
 | state | [NodeInfo.State](#neo.fs.v2.netmap.NodeInfo.State) |  | Carries state of the NeoFS node. |
 


### PR DESCRIPTION
To simplify decoding of NodeInfo structure inside netmap smart contract, the first field, also used as a storage key inside contract, has to be of the fixed length.