### PR TITLE
Add object_id signature to Head response

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -250,6 +250,12 @@ message HeadResponse {
 
       // Short object header
       ShortHeader short_header = 2;
+
+      // Signed object_id to verify full header's authenticity through following steps:
+      // 1. Calculate SHA-256 of marshalled Headers structure.
+      // 2. Check if the resulting hash matched ObjectID
+      // 3. Check if ObjectID's signature in signature field is correct.
+      neo.fs.v2.refs.Signature signature = 3;
     }
   }
   // Body of head object response message.

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -408,6 +408,7 @@ Response body
 | ----- | ---- | ----- | ----------- |
 | header | [Header](#neo.fs.v2.object.Header) |  | Full object header |
 | short_header | [ShortHeader](#neo.fs.v2.object.ShortHeader) |  | Short object header |
+| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signed object_id to verify full header's authenticity through following steps: 1. Calculate SHA-256 of marshalled Headers structure. 2. Check if the resulting hash matched ObjectID 3. Check if ObjectID's signature in signature field is correct. |
 
 
 <a name="neo.fs.v2.object.PutRequest"></a>


### PR DESCRIPTION
Object ID signature is needed to check Header authenticity.