### PR TITLE
Use tuple of full header and signature at object head response body

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -239,23 +239,29 @@ message HeadRequest {
   neo.fs.v2.session.RequestVerificationHeader verify_header = 3;
 }
 
+// Tuple of full object header and signature of object ID.
+message HeaderWithSignature {
+  // Full object header
+  Header header = 1;
+
+  // Signed object_id to verify full header's authenticity through following steps:
+  // 1. Calculate SHA-256 of marshalled Headers structure.
+  // 2. Check if the resulting hash matched ObjectID
+  // 3. Check if ObjectID's signature in signature field is correct.
+  neo.fs.v2.refs.Signature signature = 2;
+}
+
 // Head response
 message HeadResponse {
   // Response body
   message Body {
     // Carries the requested object header or it's part
     oneof head{
-      // Full object header
-      Header header = 1;
+      // Full object header with object ID signature
+      Header HeaderWithSignature = 1;
 
       // Short object header
       ShortHeader short_header = 2;
-
-      // Signed object_id to verify full header's authenticity through following steps:
-      // 1. Calculate SHA-256 of marshalled Headers structure.
-      // 2. Check if the resulting hash matched ObjectID
-      // 3. Check if ObjectID's signature in signature field is correct.
-      neo.fs.v2.refs.Signature signature = 3;
     }
   }
   // Body of head object response message.


### PR DESCRIPTION
Object.Head method returns either full header or short header. Since it can't return anything else, signature must be paired with full header in explicit tuple message.