### PR TITLE
Clarify object search and ACL filters header references

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -97,6 +97,29 @@ message EACLRecord {
   Action action = 2 [json_name = "action"];
 
   // Filter to check particular properties of the request or object.
+  //
+  // By default `header_name` field refers to the corresponding object's
+  // `Attribute`. Some Object's header fields can also be accessed by adding
+  // `$Object:` prefix to the name. Here is the list of fields available via
+  // this prefix:
+  //
+  // * $Object:version \
+  //   version
+  // * $Object:containerID \
+  //   container_id
+  // * $Object:ownerID \
+  //   owner_id
+  // * $Object:creationEpoch \
+  //   creation_epoch
+  // * $Object:payloadLength \
+  //   payload_length
+  // * $Object:payloadHash \
+  //   payload_hash
+  // * $Object:objectType \
+  //   object_type
+  // * $Object:homomorphicHash \
+  //   homomorphic_hash
+  //
   message Filter {
     // Define if Object or Request header will be used
     HeaderType header_type = 1 [json_name = "headerType"];

--- a/object/service.proto
+++ b/object/service.proto
@@ -295,15 +295,52 @@ message SearchRequest {
 
     // Version of the Query Language used
     uint32 version = 2;
-    // Filter structure
+    // Filter structure checks if object header field or attribute content
+    // matches a value.
+    //
+    // By default `name` field refers to the corresponding object's `Attribute`.
+    // Some Object's header fields can also be accessed by adding `$Object:`
+    // prefix to the name. Here is the list of fields available via this prefix:
+    //
+    // * $Object:version \
+    //   version
+    // * $Object:containerID \
+    //   container_id
+    // * $Object:ownerID \
+    //   owner_id
+    // * $Object:creationEpoch \
+    //   creation_epoch
+    // * $Object:payloadLength \
+    //   payload_length
+    // * $Object:payloadHash \
+    //   payload_hash
+    // * $Object:objectType \
+    //   object_type
+    // * $Object:homomorphicHash \
+    //   homomorphic_hash
+    //
+    // There are some well-known filter aliases to match objects by certain
+    // properties:
+    //
+    // * $Object:ROOT \
+    //   With the `value` set to `true` checks if an object is a top object in a
+    //   split hierarchy. With other values returns non-root objects.
+    // * $Object:LEAF \
+    //   With the `value` set to `true` checks if an object is a leaf in a split
+    //   hierarchy. With other values returns non-leaf objects.
+    // * $Object:PARENT \
+    //   With the `value` set to `true` checks if an object has any child
+    //   objects is `Split` header or there are objects known to reference this
+    //   object as a parent. If set to `false` returns object without child
+    //   objects in `Split` header or any objects known to reference them.
     message Filter {
       // Match type to use
       MatchType match_type = 1;
 
-      // Header name to match
+      // Attribute or Header fields to match
       string name = 2;
 
-      // Header value to match
+      // Value to match
       string value = 3;
     }
     // List of search expressions

--- a/object/types.proto
+++ b/object/types.proto
@@ -124,7 +124,7 @@ message Header {
     neo.fs.v2.refs.ObjectID previous = 2 [json_name = "previous"];
 
     // `signature` field of the parent object. Used to reconstruct parent.
-    neo.fs.v2.refs.Signature parent_signature = 3[json_name = "parentSignature"];
+    neo.fs.v2.refs.Signature parent_signature = 3 [json_name = "parentSignature"];
 
     // `header` field of the parent object. Used to reconstruct parent.
     Header parent_header = 4 [json_name = "parentHeader"];


### PR DESCRIPTION
Describing a way to access not only object attributes, but also specific header fields.