### PR TITLE
Rename object search and ACL filters fields for consistency

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -98,10 +98,9 @@ message EACLRecord {
 
   // Filter to check particular properties of the request or object.
   //
-  // By default `header_name` field refers to the corresponding object's
-  // `Attribute`. Some Object's header fields can also be accessed by adding
-  // `$Object:` prefix to the name. Here is the list of fields available via
-  // this prefix:
+  // By default `key` field refers to the corresponding object's `Attribute`.
+  // Some Object's header fields can also be accessed by adding `$Object:`
+  // prefix to the name. Here is the list of fields available via this prefix:
   //
   // * $Object:version \
   //   version
@@ -128,10 +127,10 @@ message EACLRecord {
     MatchType match_type = 2 [json_name = "matchType"];
 
     // Name of the Header to use
-    string header_name = 3 [json_name="headerName"];
+    string key = 3 [json_name="key"];
 
     // Expected Header Value or pattern to match
-    string header_val = 4 [json_name="value"];
+    string value = 4 [json_name="value"];
   }
 
   // List of filters to match and see if rule is applicable

--- a/object/service.proto
+++ b/object/service.proto
@@ -298,7 +298,7 @@ message SearchRequest {
     // Filter structure checks if object header field or attribute content
     // matches a value.
     //
-    // By default `name` field refers to the corresponding object's `Attribute`.
+    // By default `key` field refers to the corresponding object's `Attribute`.
     // Some Object's header fields can also be accessed by adding `$Object:`
     // prefix to the name. Here is the list of fields available via this prefix:
     //
@@ -338,7 +338,7 @@ message SearchRequest {
       MatchType match_type = 1;
 
       // Attribute or Header fields to match
-      string name = 2;
+      string key = 2;
 
       // Value to match
       string value = 3;

--- a/proto-docs/acl.md
+++ b/proto-docs/acl.md
@@ -38,6 +38,9 @@ like [JWT](https://jwt.io), it has a limited lifetime and scope, hence can be
 used in the similar use cases, like providing authorisation to externally
 authenticated party.
 
+BearerToken can be issued only by container's owner and must be signed using
+the key associated with container's `OwnerID`.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -55,7 +58,7 @@ owner with additional information preventing token's abuse.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | eacl_table | [EACLTable](#neo.fs.v2.acl.EACLTable) |  | Table of Extended ACL rules to use instead of the ones attached to the container |
-| owner_id | [neo.fs.v2.refs.OwnerID](#neo.fs.v2.refs.OwnerID) |  | `OwnerID` to whom the token was issued. MUST match with the request originator's `OwnerID` |
+| owner_id | [neo.fs.v2.refs.OwnerID](#neo.fs.v2.refs.OwnerID) |  | `OwnerID` to whom the token was issued. Must match the request originator's `OwnerID`. If empty, any token bearer will be accepted. |
 | lifetime | [BearerToken.Body.TokenLifetime](#neo.fs.v2.acl.BearerToken.Body.TokenLifetime) |  | Token expiration and valid time period parameters |
 
 
@@ -92,13 +95,34 @@ Describes a single eACL rule.
 ### Message EACLRecord.Filter
 Filter to check particular properties of the request or object.
 
+By default `key` field refers to the corresponding object's `Attribute`.
+Some Object's header fields can also be accessed by adding `$Object:`
+prefix to the name. Here is the list of fields available via this prefix:
+
+* $Object:version \
+  version
+* $Object:containerID \
+  container_id
+* $Object:ownerID \
+  owner_id
+* $Object:creationEpoch \
+  creation_epoch
+* $Object:payloadLength \
+  payload_length
+* $Object:payloadHash \
+  payload_hash
+* $Object:objectType \
+  object_type
+* $Object:homomorphicHash \
+  homomorphic_hash
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | header_type | [HeaderType](#neo.fs.v2.acl.HeaderType) |  | Define if Object or Request header will be used |
 | match_type | [MatchType](#neo.fs.v2.acl.MatchType) |  | Match operation type |
-| header_name | [string](#string) |  | Name of the Header to use |
-| header_val | [string](#string) |  | Expected Header Value or pattern to match |
+| key | [string](#string) |  | Name of the Header to use |
+| value | [string](#string) |  | Expected Header Value or pattern to match |
 
 
 <a name="neo.fs.v2.acl.EACLRecord.Target"></a>

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -468,9 +468,16 @@ creation and cna never be added or updated.
 
 There are some "well-known" attributes affecting system behaviour:
 
-* Subnet \
+* __NEOFS__SUBNET \
   String ID of container's storage subnet. Container can be attached to
   only one subnet.
+
+And some well-known attributes used by applications only:
+
+* Name \
+  Human-friendly name
+* Timestamp \
+  User-defined local time of container creation in Unix Timestamp format
 
 
 | Field | Type | Label | Description |

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -542,14 +542,51 @@ Object Search request body
 <a name="neo.fs.v2.object.SearchRequest.Body.Filter"></a>
 
 ### Message SearchRequest.Body.Filter
-Filter structure
+Filter structure checks if object header field or attribute content
+matches a value.
+
+By default `key` field refers to the corresponding object's `Attribute`.
+Some Object's header fields can also be accessed by adding `$Object:`
+prefix to the name. Here is the list of fields available via this prefix:
+
+* $Object:version \
+  version
+* $Object:containerID \
+  container_id
+* $Object:ownerID \
+  owner_id
+* $Object:creationEpoch \
+  creation_epoch
+* $Object:payloadLength \
+  payload_length
+* $Object:payloadHash \
+  payload_hash
+* $Object:objectType \
+  object_type
+* $Object:homomorphicHash \
+  homomorphic_hash
+
+There are some well-known filter aliases to match objects by certain
+properties:
+
+* $Object:ROOT \
+  With the `value` set to `true` checks if an object is a top object in a
+  split hierarchy. With other values returns non-root objects.
+* $Object:LEAF \
+  With the `value` set to `true` checks if an object is a leaf in a split
+  hierarchy. With other values returns non-leaf objects.
+* $Object:PARENT \
+  With the `value` set to `true` checks if an object has any child
+  objects is `Split` header or there are objects known to reference this
+  object as a parent. If set to `false` returns object without child
+  objects in `Split` header or any objects known to reference them.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | match_type | [MatchType](#neo.fs.v2.object.MatchType) |  | Match type to use |
-| name | [string](#string) |  | Header name to match |
-| value | [string](#string) |  | Header value to match |
+| key | [string](#string) |  | Attribute or Header fields to match |
+| value | [string](#string) |  | Value to match |
 
 
 <a name="neo.fs.v2.object.SearchResponse"></a>
@@ -620,8 +657,19 @@ object.
 There are some "well-known" attributes starting with `__NEOFS__` prefix
 that affect system behaviour:
 
-* __NEOFS__UPLOAD_ID
-* __NEOFS__EXPIRATION_EPOCH
+* __NEOFS__UPLOAD_ID \
+  Marks smaller parts of a split bigger object
+* __NEOFS__EXPIRATION_EPOCH \
+  Tells GC to delete object after that epoch
+
+And some well-known attributes used by applications only:
+
+* Name \
+  Human-friendly name
+* FileName \
+  File name to be associated with the object on saving
+* Timestamp \
+  User-defined local time of object creation in Unix Timestamp format
 
 For detailed description of each well-known attribute please see the
 corresponding section in NeoFS Technical specification.


### PR DESCRIPTION
Make object search and ACL filters use the same field names, as they are used for the very similar functionality.