### PR TITLE
Add split_info field in object.GetResponse body

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -102,6 +102,9 @@ message GetResponse {
 
       // Chunked object payload
       bytes chunk = 2;
+
+      // Meta information of split hierarchy for object assembly.
+      SplitInfo split_info = 3;
     }
   }
   // Body of get object response message.

--- a/object/types.proto
+++ b/object/types.proto
@@ -160,3 +160,21 @@ message Object {
   // Payload bytes.
   bytes payload = 4 [json_name = "payload"];
 }
+
+// Meta information of split hierarchy for object assembly. With last part
+// one can traverse linked list of split hierarchy back to first part and
+// assemble original object. With linking object one can assembly object
+// straight away from the object parts.
+message SplitInfo {
+  // 16 byte UUID used to identify the split object hierarchy parts.
+  bytes split_id = 1;
+
+  // Identifier of the last object in split hierarchy parts. It contains
+  // split header with original object header.
+  neo.fs.v2.refs.ObjectID last_part = 2;
+
+  // Identifier of linking object for split hierarchy parts. It contains
+  // split header with original object header and sorted list of
+  // object parts.
+  neo.fs.v2.refs.ObjectID link = 3;
+}


### PR DESCRIPTION
SplitInfo structure from split_info field contains meta information to assembly the object that has been split into parts.