### PR TITLE
Clarify that Attributes can't have empty values

### DIFF
--- a/container/types.proto
+++ b/container/types.proto
@@ -28,8 +28,10 @@ message Container {
   uint32 basic_acl = 4 [json_name = "basicACL"];
 
   // `Attribute` is a user-defined Key-Value metadata pair attached to the
-  // container. Container attribute are immutable. They are set at container
-  // creation and cna never be added or updated.
+  // container. Container attributes are immutable. They are set at container
+  // creation and can never be added or updated.
+  //
+  // Key name must be a valid UTF-8 string. Value can't be empty.
   //
   // There are some "well-known" attributes affecting system behaviour:
   //

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -131,6 +131,9 @@ message NodeInfo {
 
   // Administrator-defined Attributes of the NeoFS Storage Node.
   //
+  // `Attribute` is a Key-Value metadata pair. Key name must be a valid UTF-8
+  // string. Value can't be empty.
+  //
   // Node's attributes are mostly used during Storage Policy evaluation to
   // calculate object's placement and find a set of nodes satisfying policy
   // requirements. There are some "well-known" node attributes common to all the

--- a/object/types.proto
+++ b/object/types.proto
@@ -86,6 +86,8 @@ message Header {
   // `Attribute` is a user-defined Key-Value metadata pair attached to the
   // object.
   //
+  // Key name must be a valid UTF-8 string. Value can't be empty.
+  //
   // There are some "well-known" attributes starting with `__NEOFS__` prefix
   // that affect system behaviour:
   //


### PR DESCRIPTION
In case there is a need to set flag-like attributes, the value should be set to something like `true` or `1`.

Closes: #86 