### PR TITLE
Remove ACL filter unusable in ACL context

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -106,8 +106,6 @@ message EACLRecord {
   //   version
   // * $Object:objectID \
   //   object_id
-  // * $Object:containerID \
-  //   container_id
   // * $Object:ownerID \
   //   owner_id
   // * $Object:creationEpoch \


### PR DESCRIPTION
Removing `$Object:containerID`, because requests are already limited to container scope and NeoFS doesn't support cross-container operations.

Closes #85