### PR TITLE
Clarify that attribute names must be unique

### DIFF
--- a/container/types.proto
+++ b/container/types.proto
@@ -31,7 +31,9 @@ message Container {
   // container. Container attributes are immutable. They are set at container
   // creation and can never be added or updated.
   //
-  // Key name must be a valid UTF-8 string. Value can't be empty.
+  // Key name must be a container-unique valid UTF-8 string. Value can't be
+  // empty. Containers with duplicated attribute names or attributes with empty
+  // values will be considered invalid.
   //
   // There are some "well-known" attributes affecting system behaviour:
   //

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -179,7 +179,10 @@ message NodeInfo {
     // `Country`.
     repeated string parents = 3 [json_name = "parents"];
   }
-  // Carries list of the NeoFS node attributes in a string key-value format.
+  // Carries list of the NeoFS node attributes in a key-value form. Key name
+  // must be a node-unique valid UTF-8 string. Value can't be empty. NodeInfo
+  // structures with duplicated attribute names or attributes with empty values
+  // will be considered invalid.
   repeated Attribute attributes = 3 [json_name = "attributes"];
 
   // Represents the enumeration of various states of the NeoFS node.

--- a/object/types.proto
+++ b/object/types.proto
@@ -92,7 +92,9 @@ message Header {
   // `Attribute` is a user-defined Key-Value metadata pair attached to the
   // object.
   //
-  // Key name must be a valid UTF-8 string. Value can't be empty.
+  // Key name must be a object-unique valid UTF-8 string. Value can't be empty.
+  // Objects with duplicated attribute names or attributes with empty values
+  // will be considered invalid.
   //
   // There are some "well-known" attributes starting with `__NEOFS__` prefix
   // that affect system behaviour:


### PR DESCRIPTION
All types of attribute keys must be unique and can't be repeated in the same entity.

- Containers with duplicated attribute keys must not be accepted by InnerRing on creation.
- Nodes with duplicated attribute keys can't be accepted to NetMap by InnerRing
- Objects with duplicated attribute keys must be considered invalid and not accepted in PUT operations

Closes #81