### PR TITLE
Clarify JSON encoding for OID, CID and OwnerID

### DIFF
--- a/refs/types.proto
+++ b/refs/types.proto
@@ -19,10 +19,19 @@ message Address {
 // NeoFS Object unique identifier. Objects are immutable and content-addressed.
 // It means `ObjectID` will change if `header` or `payload` changes.
 //
-// `ObjectID` is a 32 byte long SHA256 hash of object's `header` field, which,
-// in it's turn, contains hash of object's payload.
+// `ObjectID` is a 32 byte long
+// [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
+// object's `header` field, which, in it's turn, contains hash of object's
+// payload.
 //
-// String presentation is base58 encoded string.
+// String presentation is
+// [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.
+//
+// JSON value will be the data encoded as a string using standard base64
+// encoding with paddings. Either
+// [standard](https://tools.ietf.org/html/rfc4648#section-4) or
+// [URL-safe](https://tools.ietf.org/html/rfc4648#section-5) base64 encoding
+// with/without paddings are accepted.
 message ObjectID {
   // Object identifier in a binary format
   bytes value = 1 [json_name = "value"];
@@ -31,10 +40,18 @@ message ObjectID {
 // NeoFS container identifier. Container structures are immutable and
 // content-addressed.
 //
-// `ContainerID` is a 32 byte long SHA256 hash of stable-marshalled container
-// message.
+// `ContainerID` is a 32 byte long
+// [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
+// stable-marshalled container message.
 //
-// String presentation is base58 encoded string.
+// String presentation is
+// [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.
+//
+// JSON value will be the data encoded as a string using standard base64
+// encoding with paddings. Either
+// [standard](https://tools.ietf.org/html/rfc4648#section-4) or
+// [URL-safe](https://tools.ietf.org/html/rfc4648#section-5) base64 encoding
+// with/without paddings are accepted.
 message ContainerID {
   // Container identifier in a binary format.
   bytes value = 1 [json_name = "value"];
@@ -47,7 +64,14 @@ message ContainerID {
 // `OwnerID` is a 25 bytes sequence starting with Neo version prefix byte
 // followed by 20 bytes of ScrptHash and 4 bytes of checksum.
 //
-// String presentation is Base58 Check Encoded string.
+// String presentation is [Base58
+// Check](https://en.bitcoin.it/wiki/Base58Check_encoding) Encoded string.
+//
+// JSON value will be the data encoded as a string using standard base64
+// encoding with paddings. Either
+// [standard](https://tools.ietf.org/html/rfc4648#section-4) or
+// [URL-safe](https://tools.ietf.org/html/rfc4648#section-5) base64 encoding
+// with/without paddings are accepted.
 message OwnerID {
   // Identifier of the container owner in a binary format
   bytes value = 1 [json_name = "value"];


### PR DESCRIPTION
It may be confusing to findout that JSON-encoded protobuf `bytes` are base64 encoded and it's not the same format as String representation. 