### PR TITLE
Clarify object field usage in some requests' eACL filters

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -121,6 +121,11 @@ message EACLRecord {
   // * $Object:homomorphicHash \
   //   homomorphic_hash
   //
+  // Please note, that if request or response does not have object's headers or
+  // full object (Range, RangeHash, Search, Delete), it will not be possible to
+  // filter by object header fields or user attributes. From the well-known list
+  // only `$Object:objectID` and `$Object:containerID` will be available, as
+  // it's possible to take that information from the requested address.
   message Filter {
     // Define if Object or Request header will be used
     HeaderType header_type = 1 [json_name = "headerType"];


### PR DESCRIPTION
Related: nspcc-dev/neofs-node#247