### PR TITLE
Add version and complete flag

### DIFF
--- a/audit/types.proto
+++ b/audit/types.proto
@@ -10,37 +10,44 @@ import "refs/types.proto";
 // DataAuditResult keeps record of conducted Data Audits. The detailed report is
 // generated separately.
 message DataAuditResult {
+  // Data Audit Result format version. Effectively the version of API library
+  // used to report DataAuditResult structure.
+  neo.fs.v2.refs.Version version = 1 [json_name = "version"];
+
   // Epoch number when the Data Audit was conducted
-  fixed64 audit_epoch = 1 [json_name = "auditEpoch"];
+  fixed64 audit_epoch = 2 [json_name = "auditEpoch"];
 
   // Container under audit
-  neo.fs.v2.refs.ContainerID container_id = 2 [json_name = "containerID"];
+  neo.fs.v2.refs.ContainerID container_id = 3 [json_name = "containerID"];
 
   // Public key of the auditing InnerRing node in a binary format
-  bytes public_key = 3 [json_name = "publicKey"];
+  bytes public_key = 4 [json_name = "publicKey"];
+
+  // Shows if Data Audit process was complete in time or if it was cancelled
+  bool complete = 5 [json_name = "complete"];
 
   // List of Storage Groups that passed audit PoR stage
-  repeated neo.fs.v2.refs.ObjectID pass_sg = 4 [json_name = "passSG"];
+  repeated neo.fs.v2.refs.ObjectID pass_sg = 6 [json_name = "passSG"];
 
   // List of Storage Groups that failed audit PoR stage
-  repeated neo.fs.v2.refs.ObjectID fail_sg = 5 [json_name = "failSG"];
+  repeated neo.fs.v2.refs.ObjectID fail_sg = 7 [json_name = "failSG"];
 
   // Number of sampled objects under audit placed in an optimal way according to
   // the containers placement policy when checking PoP
-  uint32 hit = 6 [json_name = "hit"];
+  uint32 hit = 8 [json_name = "hit"];
 
   // Number of sampled objects under audit placed in suboptimal way according to
   // the containers placement policy, but still at a satisfactory level when
   // checking PoP
-  uint32 miss = 7 [json_name = "miss"];
+  uint32 miss = 9 [json_name = "miss"];
 
   // Number of sampled objects under audit stored in a way not confirming
   // placement policy or not found at all when checking PoP
-  uint32 fail = 8 [json_name = "fail"];
+  uint32 fail = 10 [json_name = "fail"];
 
   // List of storage node public keys that passed at least one PDP
-  repeated bytes pass_nodes = 9 [json_name = "passNodes"];
+  repeated bytes pass_nodes = 11 [json_name = "passNodes"];
 
   // List of storage node public keys that failed at least one PDP
-  repeated bytes fail_nodes = 10 [json_name = "failNodes"];
+  repeated bytes fail_nodes = 12 [json_name = "failNodes"];
 }

--- a/proto-docs/audit.md
+++ b/proto-docs/audit.md
@@ -31,9 +31,11 @@ generated separately.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| version | [neo.fs.v2.refs.Version](#neo.fs.v2.refs.Version) |  | Data Audit Result format version. Effectively the version of API library used to report DataAuditResult structure. |
 | audit_epoch | [fixed64](#fixed64) |  | Epoch number when the Data Audit was conducted |
 | container_id | [neo.fs.v2.refs.ContainerID](#neo.fs.v2.refs.ContainerID) |  | Container under audit |
 | public_key | [bytes](#bytes) |  | Public key of the auditing InnerRing node in a binary format |
+| complete | [bool](#bool) |  | Shows if Data Audit process was complete in time or if it was cancelled |
 | pass_sg | [neo.fs.v2.refs.ObjectID](#neo.fs.v2.refs.ObjectID) | repeated | List of Storage Groups that passed audit PoR stage |
 | fail_sg | [neo.fs.v2.refs.ObjectID](#neo.fs.v2.refs.ObjectID) | repeated | List of Storage Groups that failed audit PoR stage |
 | hit | [uint32](#uint32) |  | Number of sampled objects under audit placed in an optimal way according to the containers placement policy when checking PoP |


### PR DESCRIPTION
The `version` field required for having IR nodes with different software versions working together.
The `complete` flag needed for marking audits that didn't finish because of time out or some other reasons. The exact reason should be written in Audit Report separately.