### PR TITLE
Describe well-known X-Headers

### DIFF
--- a/session/service.proto
+++ b/session/service.proto
@@ -21,7 +21,7 @@ service SessionService {
 message CreateRequest {
   // Session creation request body
   message Body {
-    // Dession initiating user's or node's key derived `OwnerID`.
+    // Session initiating user's or node's key derived `OwnerID`
     neo.fs.v2.refs.OwnerID owner_id = 1;
     // Session expiration `Epoch`
     uint64 expiration = 2;

--- a/session/types.proto
+++ b/session/types.proto
@@ -85,7 +85,25 @@ message SessionToken {
   neo.fs.v2.refs.Signature signature = 2 [json_name = "signature"];
 }
 
-// Extended headers for Request/Response.
+// Extended headers for Request/Response. May contain any user-defined headers
+// to be interpreted on application level.
+//
+// Key name must be unique valid UTF-8 string. Value can't be empty. Requests or
+// Responses with duplicated header names or headers with empty values will be
+// considered invalid.
+//
+// There are some "well-known" headers starting with `__NEOFS__` prefix that
+// affect system behaviour:
+//
+// * __NEOFS__NETMAP_EPOCH \
+//   Netmap epoch to use for object placement calculation. The `value` is string
+//   encoded `uint64` in decimal presentation. If set to '0' or not set, the
+//   current epoch only will be used.
+// * __NEOFS__NETMAP_LOOKUP_DEPTH \
+//   If object can't be found using current epoch's netmap, this header limits
+//   how many past epochs back the node can lookup. The `value` is string
+//   encoded `uint64` in decimal presentation. If set to '0' or not set, the
+//   current epoch only will be used.
 message XHeader {
   // Key of the X-Header
   string key = 1 [json_name = "key"];


### PR DESCRIPTION
When object can't be found using current network map, there is a chance to find it using netmap versions from previous epochs.

By default only current netmap is used. Well-known X-Headers can be used to set the specific netmap version and limit how deep into the past the node can go in the search of an object.

Closes #117 