### PR TITLE
object: Add json_name tags to fields of SearchRequest.Body.Filter

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -356,13 +356,13 @@ message SearchRequest {
     // Behavior when processing this kind of filters is undefined.
     message Filter {
       // Match type to use
-      MatchType match_type = 1;
+      MatchType match_type = 1 [json_name = "matchType"];
 
       // Attribute or Header fields to match
-      string key = 2;
+      string key = 2 [json_name = "key"];
 
       // Value to match
-      string value = 3;
+      string value = 3 [json_name = "value"];
     }
     // List of search expressions
     repeated Filter filters = 3;


### PR DESCRIPTION
According to the given need https://github.com/nspcc-dev/neofs-api-go/issues/255 object search filters must support strict JSON format. This need originally appeared in https://github.com/nspcc-dev/neofs-node/issues/362. There are two possible solutions:

1. use CLI-specific JSON format
2. use API JSON format (as expected in https://github.com/nspcc-dev/neofs-api-go/issues/255)

To solve the problem in method 2, it is required to explicitly set the `json_name` field tags.