### PR TITLE
Extend list of node attributes with UN/LOCODE-related attributes

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -160,6 +160,8 @@ message NodeInfo {
   //   Country code in
   //   [ISO 3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
   //   format. Calculated automatically from `Locode` attribute
+  // * LocationCode \
+  //   TODO: write description.
   // * Region \
   //   Country's administative subdivision where node is located. Calculated
   //   automatically from `Locode` attribute based on `SubDiv` field. Presented

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -164,6 +164,8 @@ message NodeInfo {
   //   TODO: write description.
   // * Location \
   //   TODO: write description.
+  // * SubDivCode \
+  //   TODO: write description.
   // * Region \
   //   Country's administative subdivision where node is located. Calculated
   //   automatically from `Locode` attribute based on `SubDiv` field. Presented

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -154,6 +154,8 @@ message NodeInfo {
   //   Node's geographic location in
   //   [UN/LOCODE](https://www.unece.org/cefact/codesfortrade/codes_index.html)
   //   format approximated to the nearest point defined in standard.
+  // * CountryCode \
+  //   TODO: write description.
   // * Country \
   //   Country code in
   //   [ISO 3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -162,6 +162,8 @@ message NodeInfo {
   //   format. Calculated automatically from `Locode` attribute
   // * LocationCode \
   //   TODO: write description.
+  // * Location \
+  //   TODO: write description.
   // * Region \
   //   Country's administative subdivision where node is located. Calculated
   //   automatically from `Locode` attribute based on `SubDiv` field. Presented

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -150,7 +150,7 @@ message NodeInfo {
   // * Subnet \
   //   String ID of Node's storage subnet. There can be only one subnet served
   //   by the Storage Node.
-  // * Locode \
+  // * UN-LOCODE \
   //   Node's geographic location in
   //   [UN/LOCODE](https://www.unece.org/cefact/codesfortrade/codes_index.html)
   //   format approximated to the nearest point defined in standard.

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -153,30 +153,34 @@ message NodeInfo {
   // * UN-LOCODE \
   //   Node's geographic location in
   //   [UN/LOCODE](https://www.unece.org/cefact/codesfortrade/codes_index.html)
-  //   format approximated to the nearest point defined in standard.
+  //   format approximated to the nearest point defined in the standard.
   // * CountryCode \
-  //   TODO: write description.
-  // * Country \
   //   Country code in
   //   [ISO 3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-  //   format. Calculated automatically from `Locode` attribute
-  // * LocationCode \
-  //   TODO: write description.
+  //   format. Calculated automatically from `UN-LOCODE` attribute.
+  // * Country \
+  //   Country short name in English, as defined in
+  //   [ISO-3166](https://www.iso.org/obp/ui/#search). Calculated automatically
+  //   from `UN-LOCODE` attribute.
   // * Location \
-  //   TODO: write description.
+  //   Place names are given, whenever possible, in their national language
+  //   versions as expressed in the Roman alphabet using the 26 characters of
+  //   the character set adopted for international trade data interchange,
+  //   written without diacritics . Calculated automatically from `UN-LOCODE`
+  //   attribute.
   // * SubDivCode \
-  //   TODO: write description.
+  //   Country's administrative subdivision where node is located. Calculated
+  //   automatically from `UN-LOCODE` attribute based on `SubDiv` field.
+  //   Presented in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)
+  //   format.
   // * SubDiv \
-  //   TODO: write description.
+  //   Country's administrative subdivision name, as defined in
+  //   [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2). Calculated
+  //   automatically from `UN-LOCODE` attribute.
   // * Continent \
-  //   TODO: write description.
-  // * Region \
-  //   Country's administative subdivision where node is located. Calculated
-  //   automatically from `Locode` attribute based on `SubDiv` field. Presented
-  //   in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format.
-  // * City \
-  //   City, town, village or rural area name where node is located written
-  //   without diacritics . Calculated automatically from `Locode` attribute.
+  //   Node's continent name according to the [Seven-Continent model]
+  //   (https://en.wikipedia.org/wiki/Continent#Number). Calculated
+  //   automatically from `UN-LOCODE` attribute.
   //
   // For detailed description of each well-known attribute please see the
   // corresponding section in NeoFS Technical specification.

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -166,6 +166,8 @@ message NodeInfo {
   //   TODO: write description.
   // * SubDivCode \
   //   TODO: write description.
+  // * SubDiv \
+  //   TODO: write description.
   // * Region \
   //   Country's administative subdivision where node is located. Calculated
   //   automatically from `Locode` attribute based on `SubDiv` field. Presented

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -168,6 +168,8 @@ message NodeInfo {
   //   TODO: write description.
   // * SubDiv \
   //   TODO: write description.
+  // * Continent \
+  //   TODO: write description.
   // * Region \
   //   Country's administative subdivision where node is located. Calculated
   //   automatically from `Locode` attribute based on `SubDiv` field. Presented


### PR DESCRIPTION
UN/LOCODE-relate node attributes:

- `UN-LOCODE` (ex `Locode`)
- `CountryCode` (new)
- `Country` (existing, documentation update may be required)
- `LocationCode` (new)
- `Location` (seems like `City`)
- `SubDivCode` (new)
- `SubDiv` (seems like `Region`)
-  `Continent` (new)

@realloc, please, help me to write the documentation for new attributes. N.B.:
- update `UN-LOCODE` doc if needed
- update `Country` doc if needed
- replace `City` with `Location` if needed, otherwise reconsider `City`
- replace `Region` with `SubDiv` if needed, otherwise reconsider `Region`