### PR TITLE
Same expiration epoch value in tombstone body and header

### DIFF
--- a/tombstone/types.proto
+++ b/tombstone/types.proto
@@ -11,7 +11,9 @@ import "refs/types.proto";
 // purged from the NeoFS network.
 message Tombstone {
   // Last NeoFS epoch number of the tombstone lifetime. It's set by tombstone
-  // creator depending on current NeoFS network settings.
+  // creator depending on current NeoFS network settings. Tombstone object
+  // must have the same expiration epoch value in `__NEOFS__EXPIRATION_EPOCH`
+  // attribute. Otherwise tombstone will be rejected by storage node.
   uint64 expiration_epoch = 1 [json_name = "expirationEpoch"];
 
   // 16 byte UUID used to identify the split object hierarchy parts. Must be


### PR DESCRIPTION
Expiration epoch value should be the same in tombstone object body and in tombstone object header.