### PR TITLE
Clarify empty search filter behaviour

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -308,6 +308,11 @@ message SearchRequest {
     // Filter structure checks if object header field or attribute content
     // matches a value.
     //
+    // If no filters set, search request will return all objects of the
+    // container, including Regular object, Tombstones and Storage Group
+    // objects. Most human users expect to get only object they can directly
+    // work with. In that case the `$Object:ROOT` filter should be used.
+    //
     // By default `key` field refers to the corresponding object's `Attribute`.
     // Some Object's header fields can also be accessed by adding `$Object:`
     // prefix to the name. Here is the list of fields available via this prefix:


### PR DESCRIPTION
It may be confusing for the user to get all types of objects as the result of a search with no filters set. Human users may expect to see only the objects intended for direct manipulation by humans.