### PR TITLE
Add well-known attribute for content type

### DIFF
--- a/object/types.proto
+++ b/object/types.proto
@@ -124,6 +124,8 @@ message Header {
   //   File name to be associated with the object on saving
   // * Timestamp \
   //   User-defined local time of object creation in Unix Timestamp format
+  // * Content-Type \
+  //   MIME Content Type of object's payload
   //
   // For detailed description of each well-known attribute please see the
   // corresponding section in NeoFS Technical specification.

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -699,6 +699,8 @@ And some well-known attributes used by applications only:
   File name to be associated with the object on saving
 * Timestamp \
   User-defined local time of object creation in Unix Timestamp format
+* Content-Type \
+  MIME Content Type of object's payload
 
 For detailed description of each well-known attribute please see the
 corresponding section in NeoFS Technical specification.


### PR DESCRIPTION
Neo3 Oracles need a way to check object's MIME content type, as described in neo-project/neo-modules#555.

The proposal was to add Content-Type as a well-known attribute.

Closes #141 