### PR TITLE
reputation: Add version field to GlobalTrust message

### DIFF
--- a/reputation/types.proto
+++ b/reputation/types.proto
@@ -36,6 +36,10 @@ message Trust {
 
 // Global trust value to NeoFS network peer.
 message GlobalTrust {
+    // Message format version. Effectively the version of API library used to create
+    // the message.
+    neo.fs.v2.refs.Version version = 1 [json_name = "version"];
+
     // Message body structure.
     message Body {
       // Node manager ID.
@@ -46,8 +50,8 @@ message GlobalTrust {
     }
 
     // Message body.
-    Body body = 1 [json_name = "body"];
+    Body body = 2 [json_name = "body"];
 
     // Signature of the binary `body` field by the manager.
-    refs.Signature signature = 2 [json_name = "signature"];
+    neo.fs.v2.refs.Signature signature = 3 [json_name = "signature"];
 }


### PR DESCRIPTION
Add `version` field as a first field of `GlobalTrust` message. This field
will allow you to quickly extract the version of the message from the binary
representation.

Additionally fix `signature` field's package format.

Related to #143.