### PR TITLE
Add native NFT support

### DIFF
--- a/container/service.proto
+++ b/container/service.proto
@@ -24,7 +24,7 @@ service ContainerService {
   // `Delete` invokes `Container` smart contract's `Delete` method and returns
   // response immediately. After a new block is issued in sidechain, request is
   // verified by Inner Ring nodes. After one more block in sidechain, container
-  // is added into smart contract storage.
+  // is removed from smart contract storage.
   rpc Delete(DeleteRequest) returns (DeleteResponse);
 
   // Returns container structure from `Container` smart contract storage.

--- a/container/service.proto
+++ b/container/service.proto
@@ -24,7 +24,9 @@ service ContainerService {
   // `Delete` invokes `Container` smart contract's `Delete` method and returns
   // response immediately. After a new block is issued in sidechain, request is
   // verified by Inner Ring nodes. After one more block in sidechain, container
-  // is removed from smart contract storage.
+  // is removed from smart contract storage. Only container owner has permission
+  // to perform this operation. If container has NFT-related attributes, then
+  // NFT owner is considered as container owner.
   rpc Delete(DeleteRequest) returns (DeleteResponse);
 
   // Returns container structure from `Container` smart contract storage.
@@ -34,8 +36,11 @@ service ContainerService {
   rpc List(ListRequest) returns (ListResponse);
 
   // Invokes 'SetEACL' method of 'Container` smart contract and returns response
-  // immediately. After one more block in sidechain, Extended ACL changes are
-  // added into smart contract storage.
+  // immediately. After a new block is issued in sidechain, request is verified
+  // by Inner Ring nodes. After one more block in sidechain, Extended ACL
+  // changes are added into smart contract storage. Only container owner has
+  // permission to perform this operation. If container has NFT-related
+  // attributes then NFT owner is considered as container owner.
   rpc SetExtendedACL(SetExtendedACLRequest) returns (SetExtendedACLResponse);
 
   // Returns Extended ACL table and signature from `Container` smart contract

--- a/container/types.proto
+++ b/container/types.proto
@@ -35,11 +35,32 @@ message Container {
   // empty. Containers with duplicated attribute names or attributes with empty
   // values will be considered invalid.
   //
-  // There are some "well-known" attributes affecting system behaviour:
+  // There are some "well-known" attributes affecting system behaviour.
+  //
+  // Attributes for sub networks:
   //
   // * __NEOFS__SUBNET \
   //   String ID of container's storage subnet. Container can be attached to
   //   only one subnet.
+  //
+  // NeoFS provides native support of container ownership transfer with
+  // Non-Fungible Tokens (NFT). Requests signed by NFT owner are considered as
+  // requests from container owner by storage nodes. Inner ring nodes use NFT
+  // owner address to make settlements and allow NFT owner to change
+  // extended ACL rules.
+  // To enable ownership transfer, set these container attributes:
+  //
+  // * __NEOFS__NFT-ID \
+  //   String of token ID associated with the container
+  // * __NEOFS__NFT-Address \
+  //   Address of the contract that produced NFT, encoded in LittleEndian
+  // * __NEOFS__NFT-Type \
+  //   (Optional) Type of NFT. NeoFS supports only "NEP-11" NFT (default value)
+  // * __NEOFS__NFT-Chain \
+  //   (Optional) NFT blockchain. NeoFS supports only "N3" main net
+  //   (default value)
+  // * __NEOFS__NFT-Options \
+  //   (Optional) Additional data for later use
   //
   // And some well-known attributes used by applications only:
   //


### PR DESCRIPTION
There are two important changes with NFT:

1. SetExtendedACL invocation now should be  approved by inner ring (alphabet) nodes.
2. NFT owner considered as container owner in inner ring nodes when they approve Put, Delete and SetExtendedACL invocations.