### PR TITLE
Fix string presentation of object type enum

### DIFF
--- a/object/types.proto
+++ b/object/types.proto
@@ -9,14 +9,13 @@ import "refs/types.proto";
 import "session/types.proto";
 
 // Type of the object payload content. Only `REGULAR` type objects can be split,
-// hence `TOMBSTONE` and `STORAGEGROUP` payload is limited by maximal object
+// hence `TOMBSTONE` and `STORAGE_GROUP` payload is limited by maximal object
 // size.
 //
-// String presentation of object type is PascalCased `ObjectType` enumeration
-// item name:
-// * Regular
-// * Tombstone
-// * StorageGroup
+// String presentation of object type is the same as definition:
+// * REGULAR
+// * TOMBSTONE
+// * STORAGE_GROUP
 enum ObjectType {
   // Just a normal object
   REGULAR = 0;


### PR DESCRIPTION
Default string presentations of enums in protobuf are the same as definitions. In our case it is going to be UPPER_SNAKE_CASE
string constants. Default presentation is easier to maintain. In fact neofs-api-go already use default string presentation.

Related to https://github.com/nspcc-dev/neofs-api-go/issues/332