### PR TITLE
acl: add filter for service headers

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -86,6 +86,10 @@ enum HeaderType {
 
   // Filter object headers
   OBJECT = 2;
+
+  // Filter service headers. These are not processed by NeoFS nodes and
+  // exist for service use only.
+  SERVICE = 3;
 }
 
 // Describes a single eACL rule.


### PR DESCRIPTION
Service headers are ignored by NeoFS nodes but can be
used to save access-related information by services
built on top of NeoFS.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>