### PR TITLE
session: Add sidechain magic to RequestMetaHeader

### DIFF
--- a/session/types.proto
+++ b/session/types.proto
@@ -166,6 +166,9 @@ message RequestMetaHeader {
 
   // `RequestMetaHeader` of the origin request
   RequestMetaHeader origin = 7 [json_name = "origin"];
+
+  // Network magic of NeoFS sidechain
+  uint64 sidechain_magic = 8 [json_name = "sidechainMagic"];
 }
 
 // Information about the response


### PR DESCRIPTION
Closes #82.

Please note that a new header field has been added before the origin field, although it has a higher ordinal number. In my opinion, this order will make it easier to understand the structure of the header.