### PR TITLE
Add status codes for object, container and session services.

### DIFF
--- a/proto-docs/status.md
+++ b/proto-docs/status.md
@@ -91,6 +91,29 @@ Section of failed statuses independent of the operation.
 
 
 
+<a name="neo.fs.v2.status.Container"></a>
+
+### Container
+Section of statuses for container-related operations.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CONTAINER_NOT_FOUND | 0 | [**3072**] Container not found. |
+
+
+
+<a name="neo.fs.v2.status.Object"></a>
+
+### Object
+Section of statuses for object-related operations.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ACCESS_DENIED | 0 | [**2048**] Access denied by ACL. Details: - [**0**] Human-readable description. |
+| OBJECT_NOT_FOUND | 1 | [**2049**] Object not found. |
+
+
+
 <a name="neo.fs.v2.status.Section"></a>
 
 ### Section
@@ -100,6 +123,21 @@ Section identifiers.
 | ---- | ------ | ----------- |
 | SECTION_SUCCESS | 0 | Successful return codes. |
 | SECTION_FAILURE_COMMON | 1 | Failure codes regardless of the operation. |
+| SECTION_OBJECT | 2 | Object service-specific errors. |
+| SECTION_CONTAINER | 3 | Container service-specific errors. |
+| SECTION_SESSION | 4 | Session service-specific errors. |
+
+
+
+<a name="neo.fs.v2.status.Session"></a>
+
+### Session
+Section of statuses for session-related operations.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| TOKEN_NOT_FOUND | 0 | [**4096**] Token not found. |
+| TOKEN_EXPIRED | 1 | [**4097**] Token has expired. |
 
 
 

--- a/status/types.proto
+++ b/status/types.proto
@@ -67,6 +67,9 @@ enum Section {
 
     // Object service-specific errors.
     SECTION_OBJECT = 2;
+
+    // Container service-specific errors.
+    SECTION_CONTAINER = 3;
 }
 
 // Section of NeoFS successful return codes.
@@ -100,4 +103,9 @@ enum Object {
     // [**2049**] Object not found.
     OBJECT_NOT_FOUND = 1;
 }
+
+// Section of statuses for container-related operations.
+enum Container {
+    // [**3072**] Container not found.
+    CONTAINER_NOT_FOUND = 0;
 }

--- a/status/types.proto
+++ b/status/types.proto
@@ -64,6 +64,9 @@ enum Section {
 
     // Failure codes regardless of the operation.
     SECTION_FAILURE_COMMON = 1;
+
+    // Object service-specific errors.
+    SECTION_OBJECT = 2;
 }
 
 // Section of NeoFS successful return codes.
@@ -86,4 +89,12 @@ enum CommonFail {
     //  - [**0**] Magic number of the served NeoFS network (big-endian 64-bit
     //  unsigned integer).
     WRONG_MAGIC_NUMBER = 1;
+}
+
+// Section of statuses for object-related operations.
+enum Object {
+    // [**2048**] Access denied by ACL.
+    // Details:
+    // - [**0**] Human-readable description.
+    ACCESS_DENIED = 0;
 }

--- a/status/types.proto
+++ b/status/types.proto
@@ -70,6 +70,9 @@ enum Section {
 
     // Container service-specific errors.
     SECTION_CONTAINER = 3;
+
+    // Session service-specific errors.
+    SECTION_SESSION = 4;
 }
 
 // Section of NeoFS successful return codes.
@@ -108,4 +111,12 @@ enum Object {
 enum Container {
     // [**3072**] Container not found.
     CONTAINER_NOT_FOUND = 0;
+}
+
+// Section of statuses for session-related operations.
+enum Session {
+    // [**4096**] Token not found.
+    TOKEN_NOT_FOUND = 0;
+    // [**4097**] Token has expired.
+    TOKEN_EXPIRED = 1;
 }

--- a/status/types.proto
+++ b/status/types.proto
@@ -97,4 +97,7 @@ enum Object {
     // Details:
     // - [**0**] Human-readable description.
     ACCESS_DENIED = 0;
+    // [**2049**] Object not found.
+    OBJECT_NOT_FOUND = 1;
+}
 }


### PR DESCRIPTION
Close #189, #190, #191.

1. I am not sure whether ACL-related codes should be in the Object, Container or a separate ACL section. `object.Put` acl denied seems to belong to container service, while `object.Get` is related to a specific object.
2. Prefixes are somewhat ugly IMO but necessary because of name conflicts. May be we should prefix all enum values with the service name.
3. We can also define service specific errors in related packages, which helps us with (2). Here I define them in one package.