### PR TITLE
refs: Change support for different signature schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Network magic, main status codes, object locks and notifications.
 - `LOCKED` and `LOCK_NON_REGULAR_OBJECT` status codes to `Object` section (#194)
 - `scheme` field of type `SignatureScheme` to `Signature` message which determines 
   signature scheme (#55)
+- `SignatureRFC6979` message (#203)
+
+### Changed
+- Type of `signature` field in `ContainerService` requests to `SignatureRFC6979` (#203)
 
 ## [2.11.0] - 2021-12-02 - Sinjido (신지도, 薪智島)
 

--- a/container/service.proto
+++ b/container/service.proto
@@ -97,8 +97,7 @@ message PutRequest {
     container.Container container = 1;
 
     // Signature of a stable-marshalled container according to RFC-6979.
-    // Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256.
-    neo.fs.v2.refs.Signature signature =2;
+    neo.fs.v2.refs.SignatureRFC6979 signature = 2;
   }
   // Body of container put request message.
   Body body = 1;
@@ -146,8 +145,7 @@ message DeleteRequest {
     neo.fs.v2.refs.ContainerID container_id = 1;
 
     // `ContainerID` signed with the container owner's key according to RFC-6979.
-    // Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256.
-    neo.fs.v2.refs.Signature signature = 2;
+    neo.fs.v2.refs.SignatureRFC6979 signature = 2;
   }
   // Body of container delete request message.
   Body body = 1;
@@ -210,8 +208,7 @@ message GetResponse {
     Container container = 1;
 
     // Signature of a stable-marshalled container according to RFC-6979.
-    // Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256.
-    neo.fs.v2.refs.Signature signature = 2;
+    neo.fs.v2.refs.SignatureRFC6979 signature = 2;
 
     // Session token if the container was created within a session
     neo.fs.v2.session.SessionToken session_token = 3;
@@ -279,8 +276,7 @@ message SetExtendedACLRequest {
     neo.fs.v2.acl.EACLTable eacl = 1;
 
     // Signature of stable-marshalled Extended ACL table according to RFC-6979.
-    // Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256.
-    neo.fs.v2.refs.Signature signature = 2;
+    neo.fs.v2.refs.SignatureRFC6979 signature = 2;
   }
   // Body of set extended acl request message.
   Body body = 1;
@@ -346,8 +342,7 @@ message GetExtendedACLResponse {
     neo.fs.v2.acl.EACLTable eacl = 1;
 
     // Signature of stable-marshalled Extended ACL according to RFC-6979.
-    // Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256.
-    neo.fs.v2.refs.Signature signature = 2;
+    neo.fs.v2.refs.SignatureRFC6979 signature = 2;
 
     // Session token if Extended ACL was set within a session
     neo.fs.v2.session.SessionToken session_token = 3;

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -259,7 +259,7 @@ smart contract, so signing algorithm must be supported by NeoVM.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | container_id | [neo.fs.v2.refs.ContainerID](#neo.fs.v2.refs.ContainerID) |  | Identifier of the container to delete from NeoFS |
-| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | `ContainerID` signed with the container owner's key according to RFC-6979. Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256. |
+| signature | [neo.fs.v2.refs.SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979) |  | `ContainerID` signed with the container owner's key according to RFC-6979. |
 
 
 <a name="neo.fs.v2.container.DeleteResponse"></a>
@@ -332,7 +332,7 @@ container creation.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | eacl | [neo.fs.v2.acl.EACLTable](#neo.fs.v2.acl.EACLTable) |  | Extended ACL requested, if available |
-| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of stable-marshalled Extended ACL according to RFC-6979. Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256. |
+| signature | [neo.fs.v2.refs.SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979) |  | Signature of stable-marshalled Extended ACL according to RFC-6979. |
 | session_token | [neo.fs.v2.session.SessionToken](#neo.fs.v2.session.SessionToken) |  | Session token if Extended ACL was set within a session |
 
 
@@ -383,7 +383,7 @@ was already verified on container creation.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | container | [Container](#neo.fs.v2.container.Container) |  | Requested container structure |
-| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of a stable-marshalled container according to RFC-6979. Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256. |
+| signature | [neo.fs.v2.refs.SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979) |  | Signature of a stable-marshalled container according to RFC-6979. |
 | session_token | [neo.fs.v2.session.SessionToken](#neo.fs.v2.session.SessionToken) |  | Session token if the container was created within a session |
 
 
@@ -461,7 +461,7 @@ additional signature checks.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | container | [Container](#neo.fs.v2.container.Container) |  | Container structure to register in NeoFS |
-| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of a stable-marshalled container according to RFC-6979. Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256. |
+| signature | [neo.fs.v2.refs.SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979) |  | Signature of a stable-marshalled container according to RFC-6979. |
 
 
 <a name="neo.fs.v2.container.PutResponse"></a>
@@ -514,7 +514,7 @@ reference. It will be taken from `EACLTable.container_id` field.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | eacl | [neo.fs.v2.acl.EACLTable](#neo.fs.v2.acl.EACLTable) |  | Extended ACL table to set for container |
-| signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of stable-marshalled Extended ACL table according to RFC-6979. Signature scheme must be either UNSPECIFIED or ECDSA_RFC6979_SHA256. |
+| signature | [neo.fs.v2.refs.SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979) |  | Signature of stable-marshalled Extended ACL table according to RFC-6979. |
 
 
 <a name="neo.fs.v2.container.SetExtendedACLResponse"></a>

--- a/proto-docs/refs.md
+++ b/proto-docs/refs.md
@@ -12,6 +12,7 @@
     - [ObjectID](#neo.fs.v2.refs.ObjectID)
     - [OwnerID](#neo.fs.v2.refs.OwnerID)
     - [Signature](#neo.fs.v2.refs.Signature)
+    - [SignatureRFC6979](#neo.fs.v2.refs.SignatureRFC6979)
     - [SubnetID](#neo.fs.v2.refs.SubnetID)
     - [Version](#neo.fs.v2.refs.Version)
     
@@ -148,7 +149,19 @@ Signature of something in NeoFS.
 | ----- | ---- | ----- | ----------- |
 | key | [bytes](#bytes) |  | Public key used for signing |
 | sign | [bytes](#bytes) |  | Signature |
-| scheme | [SignatureScheme](#neo.fs.v2.refs.SignatureScheme) |  | Scheme contains digital signature scheme identifier. |
+| scheme | [SignatureScheme](#neo.fs.v2.refs.SignatureScheme) |  | Scheme contains digital signature scheme identifier |
+
+
+<a name="neo.fs.v2.refs.SignatureRFC6979"></a>
+
+### Message SignatureRFC6979
+RFC 6979 signature.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [bytes](#bytes) |  | Public key used for signing |
+| sign | [bytes](#bytes) |  | Deterministic ECDSA with SHA-256 hashing |
 
 
 <a name="neo.fs.v2.refs.SubnetID"></a>
@@ -203,9 +216,8 @@ Signature scheme describes digital signing scheme used for (key, signature) pair
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| UNSPECIFIED | 0 | Unknown. The default interpretation depends on a particular structure type. |
-| ECDSA_SHA512 | 1 | ECDSA with SHA-512 hashing (FIPS 186-3). |
-| ECDSA_RFC6979_SHA256 | 2 | Deterministic ECDSA with SHA-256 hashing (RFC 6979) |
+| ECDSA_SHA512 | 0 | ECDSA with SHA-512 hashing (FIPS 186-3) |
+| ECDSA_RFC6979_SHA256 | 1 | Deterministic ECDSA with SHA-256 hashing (RFC 6979) |
 
 
  <!-- end enums -->

--- a/refs/types.proto
+++ b/refs/types.proto
@@ -105,18 +105,25 @@ message Signature {
   bytes key = 1 [json_name = "key"];
   // Signature
   bytes sign = 2 [json_name = "signature"];
-  // Scheme contains digital signature scheme identifier.
+  // Scheme contains digital signature scheme identifier
   SignatureScheme scheme = 3 [json_name = "scheme"];
 }
 
 // Signature scheme describes digital signing scheme used for (key, signature) pair.
 enum SignatureScheme {
-  // Unknown. The default interpretation depends on a particular structure type.
-  UNSPECIFIED = 0;
-  // ECDSA with SHA-512 hashing (FIPS 186-3).
-  ECDSA_SHA512 = 1;
+  // ECDSA with SHA-512 hashing (FIPS 186-3)
+  ECDSA_SHA512 = 0;
+
   // Deterministic ECDSA with SHA-256 hashing (RFC 6979)
-  ECDSA_RFC6979_SHA256 = 2;
+  ECDSA_RFC6979_SHA256 = 1;
+}
+
+// RFC 6979 signature.
+message SignatureRFC6979 {
+  // Public key used for signing
+  bytes key = 1 [json_name = "key"];
+  // Deterministic ECDSA with SHA-256 hashing
+  bytes sign = 2 [json_name = "signature"];
 }
 
 // Checksum algorithm type.


### PR DESCRIPTION
Remove `UNSPECIFIED` value from `SignatureScheme` enum. Make
`ECDSA_SHA512` to be default signature scheme (zero value).

Define `SignatureRFC6979` type for RFC-6979 signatures. Use it in
`Container` service.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>