### PR TITLE
Use well-known expiration attribute for SGs

### DIFF
--- a/proto-docs/storagegroup.md
+++ b/proto-docs/storagegroup.md
@@ -30,12 +30,17 @@ that require payed storage guaranties are gathered in `StorageGroups` with
 additional information used for proof of storage. `StorageGroup` only
 contains objects from the same container.
 
+Being an object payload, StorageGroup may have expiration Epoch set with
+`__NEOFS__EXPIRATION_EPOCH` well-known attribute. When expired, StorageGroup
+will be ignored by InnerRing nodes during Data Audit cycles and will be
+deleted by Storage Nodes.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | validation_data_size | [uint64](#uint64) |  | Total size of the payloads of objects in the storage group |
 | validation_hash | [neo.fs.v2.refs.Checksum](#neo.fs.v2.refs.Checksum) |  | Homomorphic hash from the concatenation of the payloads of the storage group members. The order of concatenation is the same as the order of the members in the `members` field. |
-| expiration_epoch | [uint64](#uint64) |  | Last NeoFS epoch number of the storage group lifetime |
+| expiration_epoch | [uint64](#uint64) |  | DEPRECATED. Last NeoFS epoch number of the storage group lifetime |
 | members | [neo.fs.v2.refs.ObjectID](#neo.fs.v2.refs.ObjectID) | repeated | Strictly ordered list of storage group member objects |
 
  <!-- end messages -->

--- a/storagegroup/types.proto
+++ b/storagegroup/types.proto
@@ -11,6 +11,12 @@ import "refs/types.proto";
 // that require payed storage guaranties are gathered in `StorageGroups` with
 // additional information used for proof of storage. `StorageGroup` only
 // contains objects from the same container.
+//
+// Being an object payload, StorageGroup may have expiration Epoch set with
+// `__NEOFS__EXPIRATION_EPOCH` well-known attribute. When expired, StorageGroup
+// will be ignored by InnerRing nodes during Data Audit cycles and will be
+// deleted by Storage Nodes.
+//
 message StorageGroup {
   // Total size of the payloads of objects in the storage group
   uint64 validation_data_size = 1 [json_name = "validationDataSize"];
@@ -20,8 +26,8 @@ message StorageGroup {
   // members in the `members` field.
   neo.fs.v2.refs.Checksum validation_hash = 2 [json_name = "validationHash"];
 
-  // Last NeoFS epoch number of the storage group lifetime
-  uint64 expiration_epoch = 3 [json_name = "expirationEpoch"];
+  // DEPRECATED. Last NeoFS epoch number of the storage group lifetime
+  uint64 expiration_epoch = 3 [json_name = "expirationEpoch", deprecated = true];
 
   // Strictly ordered list of storage group member objects
   repeated neo.fs.v2.refs.ObjectID members = 4 [json_name = "members"];


### PR DESCRIPTION
To avoid ambiguity, let's use the common well-known attribute to control both Object and Storage Group expirations.

This change affects the whole stack, including Storage and Inner Ring nodes logic. Should be merged only when we are ready to change implementation.