### PR TITLE
[#207] acl: Clarify `container_id` field meaning in the eACL table of…

### DIFF
--- a/acl/types.proto
+++ b/acl/types.proto
@@ -190,7 +190,9 @@ message BearerToken {
   // owner with additional information preventing token's abuse.
   message Body {
     // Table of Extended ACL rules to use instead of the ones attached to the
-    // container
+    // container. If it contains `container_id` field, bearer token is only
+    // valid for this specific container. Otherwise, any container of the same owner
+    // is allowed.
     EACLTable eacl_table = 1 [json_name="eaclTable"];
 
     // `OwnerID` to whom the token was issued. Must match the request


### PR DESCRIPTION
… a BearerToken

Close #207.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>