### PR TITLE
Fix/Clarify lock object usage

### DIFF
--- a/lock/types.proto
+++ b/lock/types.proto
@@ -9,7 +9,8 @@ import "refs/types.proto";
 
 // Lock objects protects a list of objects from being deleted. The lifetime of a
 // lock object is limited similar to regular objects in
-// `__NEOFS__EXPIRATION_EPOCH` attribute.
+// `__NEOFS__EXPIRATION_EPOCH` attribute. Lock object MUST have expiration epoch.
+// It is impossible to delete a lock object via ObjectService.Delete RPC call.
 message Lock {
   // List of objects to lock. Must not be empty or carry empty IDs.
   // All members must be of the `REGULAR` type.


### PR DESCRIPTION
See https://github.com/nspcc-dev/neofs-node/issues/1227#issuecomment-1138913967 for details.

Think it could wait until the whole implementation is ready and testing to prevent any breaking changes in the future (in fact I think that PR is already a breaking change).