### PR TITLE
Add netmap snapshot request

### DIFF
--- a/netmap/service.proto
+++ b/netmap/service.proto
@@ -33,6 +33,14 @@ service NetmapService {
   // information about the current network state has been successfully read;
   // - Common failures (SECTION_FAILURE_COMMON).
   rpc NetworkInfo (NetworkInfoRequest) returns (NetworkInfoResponse);
+
+  // Returns network map snapshot of the current NeoFS epoch.
+  //
+  // Statuses:
+  // - **OK** (0, SECTION_SUCCESS):
+  // information about the current network map has been successfully read;
+  // - Common failures (SECTION_FAILURE_COMMON).
+  rpc NetmapSnapshot (NetmapSnapshotRequest) returns (NetmapSnapshotResponse);
 }
 
 // Get NodeInfo structure directly from a particular node
@@ -113,4 +121,46 @@ message NetworkInfoResponse {
     // authenticate the nodes of the message route and check the correctness of
     // transmission.
     neo.fs.v2.session.ResponseVerificationHeader verify_header = 3;
+}
+
+// Get netmap snapshot request
+message NetmapSnapshotRequest {
+    // Get netmap snapshot request body.
+    message Body {
+    }
+
+    // Body of get netmap snapshot request message.
+    Body body = 1;
+
+    // Carries request meta information. Header data is used only to regulate
+    // message transport and does not affect request execution.
+    neo.fs.v2.session.RequestMetaHeader meta_header = 2;
+
+    // Carries request verification information. This header is used to
+    // authenticate the nodes of the message route and check the correctness of
+    // transmission.
+    neo.fs.v2.session.RequestVerificationHeader verify_header = 3;
+
+}
+
+// Response with current netmap snapshot
+message NetmapSnapshotResponse {
+    // Get netmap snapshot response body
+    message Body {
+        // Structure of the requested network map.
+        Netmap netmap = 1 [json_name = "netmap"];
+    }
+
+    // Body of get netmap snapshot response message.
+    Body body = 1;
+
+    // Carries response meta information. Header data is used only to regulate
+    // message transport and does not affect response execution.
+    neo.fs.v2.session.ResponseMetaHeader meta_header = 2;
+
+    // Carries response verification information. This header is used to
+    // authenticate the nodes of the message route and check the correctness of
+    // transmission.
+    neo.fs.v2.session.ResponseVerificationHeader verify_header = 3;
+
 }

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -238,6 +238,15 @@ message NodeInfo {
   State state = 4 [json_name = "state"];
 }
 
+// Network map structure
+message Netmap {
+    // Network map revision number.
+    uint64 epoch = 1 [json_name = "epoch"];
+
+    // Nodes presented in network.
+    repeated NodeInfo nodes = 2 [json_name = "nodes"];
+}
+
 // NeoFS network configuration
 message NetworkConfig {
   // Single configuration parameter


### PR DESCRIPTION
Clients need an easy way of getting network map to get connection endpoints form Node's attributes.

Related: nspcc-dev/neofs-sdk-go#297