### PR TITLE
Add FilePath object attribute

### DIFF
--- a/object/types.proto
+++ b/object/types.proto
@@ -135,6 +135,13 @@ message Header {
   //   Human-friendly name
   // * FileName \
   //   File name to be associated with the object on saving
+  // * FilePath \
+  //   Full path to be associated with the object on saving. Should start with a
+  //   '/' and use '/' as a delimiting symbol. Trailing '/' should be
+  //   interpreted as a virtual directory marker. If an object has conflicting
+  //   FilePath and FileName, FilePath should have higher priority, because it
+  //   is used to construct the directory tree. FilePath with trailing '/' and
+  //   non-empty FileName attribute should not be used together.
   // * Timestamp \
   //   User-defined local time of object creation in Unix Timestamp format
   // * Content-Type \


### PR DESCRIPTION
FilePath attribute is already used by S3 and HTTP protocol gateways.
Also seen in [Gaspump](https://github.com/configwizard/gaspump-api/), NeoFS.Send and NeoFS.CDN.

Closes: #238 