### PR TITLE
Add a well-known attribute for additional addresses

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -202,6 +202,10 @@ message NodeInfo {
   //   Node's continent name according to the [Seven-Continent model]
   //   (https://en.wikipedia.org/wiki/Continent#Number). Calculated
   //   automatically from `UN-LOCODE` attribute.
+  // * ExternalAddr
+  //   Node's preferred way for communications with external clients.
+  //   Clients SHOULD use these addresses if possible.
+  //   Must contain a comma-separated list of multi-addresses.
   //
   // For detailed description of each well-known attribute please see the
   // corresponding section in NeoFS Technical Specification.


### PR DESCRIPTION
The task says "external" but wouldn't "internal" be better here? I mean for backwards compatibility we have a single address to which user connects and optional internal addresses to use for storage nodes.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>