### PR TITLE
object: Support numerical search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Numeric operands for object search queries (#265)
 
 ### Changed
 

--- a/object/service.proto
+++ b/object/service.proto
@@ -496,6 +496,9 @@ message SearchRequest {
     // objects. Most human users expect to get only object they can directly
     // work with. In that case, `$Object:ROOT` filter should be used.
     //
+    // If `match_type` field is numerical, both `value` field and object
+    // attribute MUST be base-10 integers.
+    //
     // By default `key` field refers to the corresponding object's `Attribute`.
     // Some Object's header fields can also be accessed by adding `$Object:`
     // prefix to the name. Here is the list of fields available via this prefix:

--- a/object/types.proto
+++ b/object/types.proto
@@ -47,6 +47,18 @@ enum MatchType {
 
   // String prefix match
   COMMON_PREFIX = 4;
+
+  // Numerical 'greater than'
+  NUM_GT = 5;
+
+  // Numerical 'greater or equal than'
+  NUM_GE = 6;
+
+  // Numerical 'less than'
+  NUM_LT = 7;
+
+  // Numerical 'less or equal than'
+  NUM_LE = 8;
 }
 
 // Short header fields

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -771,6 +771,9 @@ container, including Regular object, Tombstones and Storage Group
 objects. Most human users expect to get only object they can directly
 work with. In that case, `$Object:ROOT` filter should be used.
 
+If `match_type` field is numerical, both `value` field and object
+attribute MUST be base-10 integers.
+
 By default `key` field refers to the corresponding object's `Attribute`.
 Some Object's header fields can also be accessed by adding `$Object:`
 prefix to the name. Here is the list of fields available via this prefix:
@@ -1021,6 +1024,10 @@ Type of match expression
 | STRING_NOT_EQUAL | 2 | Full string mismatch |
 | NOT_PRESENT | 3 | Lack of key |
 | COMMON_PREFIX | 4 | String prefix match |
+| NUM_GT | 5 | Numerical 'greater than' |
+| NUM_GE | 6 | Numerical 'greater or equal than' |
+| NUM_LT | 7 | Numerical 'less than' |
+| NUM_LE | 8 | Numerical 'less or equal than' |
 
 
 


### PR DESCRIPTION
Previously, protocol did not support numerical search queries for objects. This may be needed for system attributes such as payload size or creation epoch, and for user ones if required by the client application.

New values of `MatchType` enumeration are added: `>`, `>=`, `<`, `<=`. These attributes allow user to search for objects with any decimal attributes. While only base-10 numbers are allowed, additional bases may be supported in the future without new enumerations

Note that the previously added `STRING_EQUAL` / `STRING_NOT_EQUAL` matchers are suitable for numerical `==` / `!=`.

Closes #265.