### PR TITLE
object/replicate: Add signature to the replication RPC

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -721,10 +721,21 @@ message ReplicateRequest {
 
   // Signature of `object.object_id.value` field.
   neo.fs.v2.refs.Signature signature = 2;
+
+  // Optional flag that requires server side to attach signature of just
+  // replicated object to ensure it has been received correctly. Signature
+  // must be calculated with a key that corresponds to an exposed to the
+  // network map public key of the object receiver.
+  bool sign_object = 3;
 }
 
 // Replicate RPC response
 message ReplicateResponse {
   // Operation execution status with one of the enumerated codes.
   neo.fs.v2.status.Status status = 1;
+
+  // Deterministic ECDSA with SHA-256 hashing (RFC 6979) signature of
+  // replicated object. Must be attached if request was made with
+  // `sign_object` flag set.
+  bytes object_signature = 2;
 }

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -721,6 +721,7 @@ Replicate RPC request
 | ----- | ---- | ----- | ----------- |
 | object | [Object](#neo.fs.v2.object.Object) |  | Object to be replicated. |
 | signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of `object.object_id.value` field. |
+| sign_object | [bool](#bool) |  | Optional flag that requires server side to attach signature of just replicated object to ensure it has been received correctly. Signature must be calculated with a key that corresponds to an exposed to the network map public key of the object receiver. |
 
 
 <a name="neo.fs.v2.object.ReplicateResponse"></a>
@@ -732,6 +733,7 @@ Replicate RPC response
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | status | [neo.fs.v2.status.Status](#neo.fs.v2.status.Status) |  | Operation execution status with one of the enumerated codes. |
+| object_signature | [bytes](#bytes) |  | Deterministic ECDSA with SHA-256 hashing (RFC 6979) signature of replicated object. Must be attached if request was made with `sign_object` flag set. |
 
 
 <a name="neo.fs.v2.object.SearchRequest"></a>


### PR DESCRIPTION
I am not sure about `create` naming.