### PR TITLE
refs: Prohibit IDs consisting of all zero bytes

### DIFF
--- a/proto-docs/refs.md
+++ b/proto-docs/refs.md
@@ -71,7 +71,8 @@ content-addressed.
 
 `ContainerID` is a 32 byte long
 [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
-stable-marshalled container message.
+stable-marshalled container message. ID consisting of all zero bytes is
+reserved for undefined value and must not be specified as a field.
 
 String presentation is a
 [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.
@@ -97,7 +98,8 @@ It means `ObjectID` will change if the `header` or the `payload` changes.
 `ObjectID` is a 32 byte long
 [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
 the object's `header` field, which, in it's turn, contains the hash of the object's
-payload.
+payload. ID consisting of all zero bytes is reserved for undefined value and
+must not be specified as a field.
 
 String presentation is a
 [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.

--- a/refs/types.proto
+++ b/refs/types.proto
@@ -22,7 +22,8 @@ message Address {
 // `ObjectID` is a 32 byte long
 // [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
 // the object's `header` field, which, in it's turn, contains the hash of the object's
-// payload.
+// payload. ID consisting of all zero bytes is reserved for undefined value and
+// must not be specified as a field.
 //
 // String presentation is a
 // [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.
@@ -42,7 +43,8 @@ message ObjectID {
 //
 // `ContainerID` is a 32 byte long
 // [SHA256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of
-// stable-marshalled container message.
+// stable-marshalled container message. ID consisting of all zero bytes is
+// reserved for undefined value and must not be specified as a field.
 //
 // String presentation is a
 // [base58](https://tools.ietf.org/html/draft-msporny-base58-02) encoded string.


### PR DESCRIPTION
i propose to reserve zero IDs and prohibit them from being message fields. While this is a breaking change in theory, in practice nothing will break. At the same time, application development will benefit