### PR TITLE
*: forbid zero byte in attributes

### DIFF
--- a/container/types.proto
+++ b/container/types.proto
@@ -33,7 +33,8 @@ message Container {
   //
   // Key name must be a container-unique valid UTF-8 string. Value can't be
   // empty. Containers with duplicated attribute names or attributes with empty
-  // values will be considered invalid.
+  // values will be considered invalid. Zero byte is also forbidden in UTF-8
+  // strings.
   //
   // There are some "well-known" attributes affecting system behaviour:
   //

--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -143,7 +143,7 @@ message NodeInfo {
   // Administrator-defined Attributes of the NeoFS Storage Node.
   //
   // `Attribute` is a Key-Value metadata pair. Key name must be a valid UTF-8
-  // string. Value can't be empty.
+  // string (without zero bytes that are forbidden). Value can't be empty.
   //
   // Attributes can be constructed into a chain of attributes: any attribute can
   // have a parent attribute and a child attribute (except the first and the last
@@ -236,9 +236,9 @@ message NodeInfo {
     repeated string parents = 3 [json_name = "parents"];
   }
   // Carries list of the NeoFS node attributes in a key-value form. Key name
-  // must be a node-unique valid UTF-8 string. Value can't be empty. NodeInfo
-  // structures with duplicated attribute names or attributes with empty values
-  // will be considered invalid.
+  // must be a node-unique valid UTF-8 string (without zero bytes). Value can't
+  // be empty. NodeInfo structures with duplicated attribute names or
+  // attributes with empty values will be considered invalid.
   repeated Attribute attributes = 3 [json_name = "attributes"];
 
   // Represents the enumeration of various states of the NeoFS node.
@@ -313,7 +313,7 @@ message NetworkConfig {
   //   Fee paid for withdrawal of funds paid by the account owner.
   //   Value: little-endian integer. Default: 0.
   message Parameter {
-    // Parameter key. UTF-8 encoded string
+    // Parameter key. UTF-8 encoded string (with no zero bytes).
     bytes key = 1 [json_name = "key"];
 
     // Parameter value

--- a/object/types.proto
+++ b/object/types.proto
@@ -201,7 +201,8 @@ message Header {
   //
   // Key name must be an object-unique valid UTF-8 string. Value can't be empty.
   // Objects with duplicated attribute names or attributes with empty values
-  // will be considered invalid.
+  // will be considered invalid. Keys and values can't contain zero bytes as
+  // well.
   //
   // There are some "well-known" attributes starting with `__NEOFS__` prefix
   // that affect system behaviour:

--- a/proto-docs/container.md
+++ b/proto-docs/container.md
@@ -586,7 +586,8 @@ container creation and can never be added or updated.
 
 Key name must be a container-unique valid UTF-8 string. Value can't be
 empty. Containers with duplicated attribute names or attributes with empty
-values will be considered invalid.
+values will be considered invalid. Zero byte is also forbidden in UTF-8
+strings.
 
 There are some "well-known" attributes affecting system behaviour:
 

--- a/proto-docs/netmap.md
+++ b/proto-docs/netmap.md
@@ -342,7 +342,7 @@ System parameters:
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| key | [bytes](#bytes) |  | Parameter key. UTF-8 encoded string |
+| key | [bytes](#bytes) |  | Parameter key. UTF-8 encoded string (with no zero bytes). |
 | value | [bytes](#bytes) |  | Parameter value |
 
 
@@ -370,7 +370,7 @@ NeoFS node description
 | ----- | ---- | ----- | ----------- |
 | public_key | [bytes](#bytes) |  | Public key of the NeoFS node in a binary format |
 | addresses | [string](#string) | repeated | Ways to connect to a node |
-| attributes | [NodeInfo.Attribute](#neo.fs.v2.netmap.NodeInfo.Attribute) | repeated | Carries list of the NeoFS node attributes in a key-value form. Key name must be a node-unique valid UTF-8 string. Value can't be empty. NodeInfo structures with duplicated attribute names or attributes with empty values will be considered invalid. |
+| attributes | [NodeInfo.Attribute](#neo.fs.v2.netmap.NodeInfo.Attribute) | repeated | Carries list of the NeoFS node attributes in a key-value form. Key name must be a node-unique valid UTF-8 string (without zero bytes). Value can't be empty. NodeInfo structures with duplicated attribute names or attributes with empty values will be considered invalid. |
 | state | [NodeInfo.State](#neo.fs.v2.netmap.NodeInfo.State) |  | Carries state of the NeoFS node |
 
 
@@ -380,7 +380,7 @@ NeoFS node description
 Administrator-defined Attributes of the NeoFS Storage Node.
 
 `Attribute` is a Key-Value metadata pair. Key name must be a valid UTF-8
-string. Value can't be empty.
+string (without zero bytes that are forbidden). Value can't be empty.
 
 Attributes can be constructed into a chain of attributes: any attribute can
 have a parent attribute and a child attribute (except the first and the last

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -837,7 +837,7 @@ Object Search request body
 | filters | [SearchFilter](#neo.fs.v2.object.SearchFilter) | repeated | List of search expressions. Limited to 8. If additional attributes are requested (see attributes below) then the first filter's key MUST be the first requested attribute. '$Object:containerID' and '$Object:objectID' filters are prohibited. |
 | cursor | [string](#string) |  | Cursor to continue search. Can be omitted or empty for the new search. |
 | count | [uint32](#uint32) |  | Limits the number of responses to the specified number. Can't be more than 1000. |
-| attributes | [string](#string) | repeated | List of attribute names (including special ones as defined by SearchFilter key) to include into the reply. Limited to 8, these attributes also affect result ordering (result is ordered by attributes and then by OID). If additional attributes are requested, then the first filter key (see filters above) MUST be the first requested attribute. '$Object:containerID' and '$Object:objectID' attributes are prohibited. |
+| attributes | [string](#string) | repeated | List of attribute names (including special ones as defined by SearchFilter key) to include into the reply. Limited to 8, these attributes also affect result ordering (result is ordered by attributes and then by OID). If additional attributes are requested, then the first filter's key (see filters above) MUST be the first requested attribute. '$Object:containerID' and '$Object:objectID' attributes are prohibited. |
 
 
 <a name="neo.fs.v2.object.SearchV2Response"></a>
@@ -920,7 +920,8 @@ object.
 
 Key name must be an object-unique valid UTF-8 string. Value can't be empty.
 Objects with duplicated attribute names or attributes with empty values
-will be considered invalid.
+will be considered invalid. Keys and values can't contain zero bytes as
+well.
 
 There are some "well-known" attributes starting with `__NEOFS__` prefix
 that affect system behaviour:


### PR DESCRIPTION
While technically this is a valid UTF-8 character in practice:
 * it's a string terminator in C and some software can help problems with it
 * we'd like to use it for internal purposes when working with DBs, it's a very convenient separator
 * no one uses it and no one should be using it