### PR TITLE
netmap: let EpochDuration be seconds

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -295,7 +295,7 @@ message NetworkConfig {
   //   Number of EigenTrust algorithm iterations to pass in the Reputation system.
   //   Value: little-endian integer. Default: 0.
   // - **EpochDuration** \
-  //   NeoFS epoch duration measured in FS chain blocks.
+  //   NeoFS epoch duration measured in seconds.
   //   Value: little-endian integer. Default: 0.
   // - **HomomorphicHashingDisabled** \
   //   Flag of disabling the homomorphic hashing of objects' payload.

--- a/proto-docs/netmap.md
+++ b/proto-docs/netmap.md
@@ -321,7 +321,7 @@ System parameters:
   Number of EigenTrust algorithm iterations to pass in the Reputation system.
   Value: little-endian integer. Default: 0.
 - **EpochDuration** \
-  NeoFS epoch duration measured in FS chain blocks.
+  NeoFS epoch duration measured in seconds.
   Value: little-endian integer. Default: 0.
 - **HomomorphicHashingDisabled** \
   Flag of disabling the homomorphic hashing of objects' payload.


### PR DESCRIPTION
All of our current networks have 1s blocks, long-term we want to have dynamic block time, but we need epochs to have some meaningful duration in astronomical time.