### PR TITLE
object: Allow header with payload chunk in first GET response message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Payload chunk field to `object.PutRequest.Init` message (#333)
 
 ### Changed
 

--- a/object/service.proto
+++ b/object/service.proto
@@ -327,7 +327,7 @@ message GetResponse {
   // GET Object Response body
   message Body {
     // Initial part of the `Object` structure stream. Technically it's a
-    // set of all `Object` structure's fields except `payload`.
+    // set of all `Object` structure's fields except `payload` is partial.
     message Init {
       // Object's unique identifier.
       neo.fs.v2.refs.ObjectID object_id = 1;
@@ -337,6 +337,9 @@ message GetResponse {
 
       // Object metadata headers
       Header header = 3;
+
+      // Payload prefix. MUST NOT be set if request API version is < `v2.26`.
+      bytes chunk = 4;
     }
     // Single message in the response stream.
     oneof object_part {

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -641,7 +641,7 @@ GET Object Response body
 
 ### Message GetResponse.Body.Init
 Initial part of the `Object` structure stream. Technically it's a
-set of all `Object` structure's fields except `payload`.
+set of all `Object` structure's fields except `payload` is partial.
 
 
 | Field | Type | Label | Description |
@@ -649,6 +649,7 @@ set of all `Object` structure's fields except `payload`.
 | object_id | [neo.fs.v2.refs.ObjectID](#neo.fs.v2.refs.ObjectID) |  | Object's unique identifier. |
 | signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signed `ObjectID` |
 | header | [Header](#neo.fs.v2.object.Header) |  | Object metadata headers |
+| chunk | [bytes](#bytes) |  | Payload prefix. MUST NOT be set if request API version is < `v2.26`. |
 
 
 <a name="neo.fs.v2.object.HeadRequest"></a>


### PR DESCRIPTION
here's an option through the proto version. It will work on the wire. The only other alternative I see is a new `GetV2` call which is more demanding of support