### PR TITLE
object: deprecate ShortHeader

### DIFF
--- a/object/service.proto
+++ b/object/service.proto
@@ -429,7 +429,9 @@ message HeadRequest {
     // Address of the object with the requested Header
     neo.fs.v2.refs.Address address = 1;
 
-    // Return only minimal header subset
+    // Return only minimal header subset.
+    //
+    // DEPRECATED. This field is ignored.
     bool main_only = 2;
 
     // If `raw` flag is set, request will work only with objects that are
@@ -474,7 +476,9 @@ message HeadResponse {
       // Full object's `Header` with `ObjectID` signature
       HeaderWithSignature header = 1;
 
-      // Short object header
+      // Short object header.
+      //
+      // DEPRECATED. Use HeaderWithSignature instead.
       ShortHeader short_header = 2;
 
       // Meta information of split hierarchy.

--- a/object/types.proto
+++ b/object/types.proto
@@ -139,6 +139,9 @@ message SearchFilter {
 }
 
 // Short header fields
+//
+// DEPRECATED. It is not supported in practice and should not be used. Use full
+// Header instead.
 message ShortHeader {
   // Object format version. Effectively, the version of API library used to
   // create particular object.

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -610,7 +610,9 @@ Object HEAD request body
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | address | [neo.fs.v2.refs.Address](#neo.fs.v2.refs.Address) |  | Address of the object with the requested Header |
-| main_only | [bool](#bool) |  | Return only minimal header subset |
+| main_only | [bool](#bool) |  | Return only minimal header subset.
+
+DEPRECATED. This field is ignored. |
 | raw | [bool](#bool) |  | If `raw` flag is set, request will work only with objects that are physically stored on the peer node |
 
 
@@ -636,7 +638,9 @@ Object HEAD response body
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | header | [HeaderWithSignature](#neo.fs.v2.object.HeaderWithSignature) |  | Full object's `Header` with `ObjectID` signature |
-| short_header | [ShortHeader](#neo.fs.v2.object.ShortHeader) |  | Short object header |
+| short_header | [ShortHeader](#neo.fs.v2.object.ShortHeader) |  | Short object header.
+
+DEPRECATED. Use HeaderWithSignature instead. |
 | split_info | [SplitInfo](#neo.fs.v2.object.SplitInfo) |  | Meta information of split hierarchy. |
 
 
@@ -1084,6 +1088,9 @@ Behavior when processing this kind of filters is undefined.
 
 ### Message ShortHeader
 Short header fields
+
+DEPRECATED. It is not supported in practice and should not be used. Use full
+Header instead.
 
 
 | Field | Type | Label | Description |


### PR DESCRIPTION
Its usage is unknown, current official implementations do not support and do not expect it.