### PR TITLE
object: add `__NEOFS__ASSOCIATE` object attribute

### DIFF
--- a/lock/types.proto
+++ b/lock/types.proto
@@ -7,6 +7,10 @@ import "refs/types.proto";
 option csharp_namespace = "Neo.FileStorage.API.Lock";
 option go_package = "github.com/nspcc-dev/neofs-sdk-go/proto/lock";
 
+// DEPRECATED: lock objects 1-to-1 with __NEOFS__ASSOCIATE object attribute in a
+// LOCK-typed object with no payload. For objects of 2.18+ API version, it is
+// prohibited to have LOCK objects with payload.
+//
 // Lock objects protects a list of objects from being deleted. The lifetime of a
 // lock object is limited similar to regular objects in
 // `__NEOFS__EXPIRATION_EPOCH` attribute. Lock object MUST have expiration epoch.

--- a/object/types.proto
+++ b/object/types.proto
@@ -210,6 +210,12 @@ message Header {
   // * __NEOFS__EXPIRATION_EPOCH \
   //   Tells GC to delete object after that epoch (but object is available
   //   throughout the epoch specified in this attribute).
+  // * __NEOFS__ASSOCIATE \
+  //   Associated object. For TOMBSTONE, LOCK object types it defines object
+  //   to delete and to lock accordingly. For objects of 2.18+ API version, it
+  //   is the only way to delete/lock objects. It MUST be a single stringified
+  //   (according to [refs.ObjectID] message) object ID with no leading or
+  //   trailing spaces.
   // * __NEOFS__TICK_EPOCH \
   //   Decimal number that defines what epoch must produce
   //   object notification with UTF-8 object address in a

--- a/proto-docs/lock.md
+++ b/proto-docs/lock.md
@@ -25,6 +25,10 @@
 <a name="neo.fs.v2.lock.Lock"></a>
 
 ### Message Lock
+DEPRECATED: lock objects 1-to-1 with __NEOFS__ASSOCIATE object attribute in a
+LOCK-typed object with no payload. For objects of 2.18+ API version, it is
+prohibited to have LOCK objects with payload.
+
 Lock objects protects a list of objects from being deleted. The lifetime of a
 lock object is limited similar to regular objects in
 `__NEOFS__EXPIRATION_EPOCH` attribute. Lock object MUST have expiration epoch.

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -929,6 +929,12 @@ that affect system behaviour:
 * __NEOFS__EXPIRATION_EPOCH \
   Tells GC to delete object after that epoch (but object is available
   throughout the epoch specified in this attribute).
+* __NEOFS__ASSOCIATE \
+  Associated object. For TOMBSTONE, LOCK object types it defines object
+  to delete and to lock accordingly. For objects of 2.18+ API version, it
+  is the only way to delete/lock objects. It MUST be a single stringified
+  (according to [refs.ObjectID] message) object ID with no leading or
+  trailing spaces.
 * __NEOFS__TICK_EPOCH \
   Decimal number that defines what epoch must produce
   object notification with UTF-8 object address in a

--- a/proto-docs/tombstone.md
+++ b/proto-docs/tombstone.md
@@ -25,6 +25,10 @@
 <a name="neo.fs.v2.tombstone.Tombstone"></a>
 
 ### Message Tombstone
+DEPRECATED: delete objects 1-to-1 with __NEOFS__ASSOCIATE object attribute in a
+TOMBSTONE-typed object with no payload. For objects of 2.18+ API version, it is
+prohibited to have TOMBSTONE objects with payload.
+
 Tombstone keeps record of deleted objects for a few epochs until they are
 purged from the NeoFS network. It is impossible to delete a tombstone object
 via ObjectService.Delete RPC call.

--- a/tombstone/types.proto
+++ b/tombstone/types.proto
@@ -7,6 +7,10 @@ import "refs/types.proto";
 option csharp_namespace = "Neo.FileStorage.API.Tombstone";
 option go_package = "github.com/nspcc-dev/neofs-sdk-go/proto/tombstone";
 
+// DEPRECATED: delete objects 1-to-1 with __NEOFS__ASSOCIATE object attribute in a
+// TOMBSTONE-typed object with no payload. For objects of 2.18+ API version, it is
+// prohibited to have TOMBSTONE objects with payload.
+//
 // Tombstone keeps record of deleted objects for a few epochs until they are
 // purged from the NeoFS network. It is impossible to delete a tombstone object
 // via ObjectService.Delete RPC call.


### PR DESCRIPTION
It obsoletes old LOCK- and TOMBSTONE-typed objects with strictly typed messages in their payloads. Closes #312, closes #311.