### PR TITLE
*: deprecate audit and storage groups

### DIFF
--- a/audit/types.proto
+++ b/audit/types.proto
@@ -9,6 +9,8 @@ option go_package = "github.com/nspcc-dev/neofs-sdk-go/proto/audit";
 
 // DataAuditResult keeps record of conducted Data Audits. The detailed report is
 // generated separately.
+//
+// DEPRECATED: This audit mechanism is no longer supported (2.18+).
 message DataAuditResult {
   // Data Audit Result format version. Effectively, the version of API library
   // used to report DataAuditResult structure.

--- a/object/types.proto
+++ b/object/types.proto
@@ -25,7 +25,7 @@ enum ObjectType {
   // Used internally to identify deleted objects
   TOMBSTONE = 1;
 
-  // StorageGroup information
+  // StorageGroup information. DEPRECATED: no longer used for audit since 2.18.
   STORAGE_GROUP = 2;
 
   // Object lock

--- a/proto-docs/audit.md
+++ b/proto-docs/audit.md
@@ -28,6 +28,8 @@
 DataAuditResult keeps record of conducted Data Audits. The detailed report is
 generated separately.
 
+DEPRECATED: This audit mechanism is no longer supported (2.18+).
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |

--- a/proto-docs/object.md
+++ b/proto-docs/object.md
@@ -1160,7 +1160,7 @@ String presentation of object type is the same as definition:
 | ---- | ------ | ----------- |
 | REGULAR | 0 | Just a normal object |
 | TOMBSTONE | 1 | Used internally to identify deleted objects |
-| STORAGE_GROUP | 2 | StorageGroup information |
+| STORAGE_GROUP | 2 | StorageGroup information. DEPRECATED: no longer used for audit since 2.18. |
 | LOCK | 3 | Object lock |
 | LINK | 4 | Object that stores child object IDs for the split objects. |
 

--- a/proto-docs/storagegroup.md
+++ b/proto-docs/storagegroup.md
@@ -35,6 +35,8 @@ Being an object payload, StorageGroup may have expiration Epoch set with
 will be ignored by InnerRing nodes during Data Audit cycles and will be
 deleted by Storage Nodes.
 
+DEPRECATED: storage groups are no longer used for audit since 2.18.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |

--- a/storagegroup/types.proto
+++ b/storagegroup/types.proto
@@ -17,6 +17,7 @@ option go_package = "github.com/nspcc-dev/neofs-sdk-go/proto/storagegroup";
 // will be ignored by InnerRing nodes during Data Audit cycles and will be
 // deleted by Storage Nodes.
 //
+// DEPRECATED: storage groups are no longer used for audit since 2.18.
 message StorageGroup {
   // Total size of the payloads of objects in the storage group
   uint64 validation_data_size = 1 [json_name = "validationDataSize"];


### PR DESCRIPTION
Both are totally unused, we better create another mechanism for this in future. Refs. https://github.com/nspcc-dev/neofs-node/issues/3442.