### PR TITLE
session: add the new signature per request field

### DIFF
--- a/proto-docs/session.md
+++ b/proto-docs/session.md
@@ -205,14 +205,19 @@ Verification info for the request signed by all intermediate nodes.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| body_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Request Body signature. Should be generated once by the request initiator. |
-| meta_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Request Meta signature is added and signed by each intermediate node |
+| body_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Request Body signature. Should be generated once by the request initiator.
+
+DEPRECATED: unused and unchecked since API v2.26, use `request_signature` as a verification instead. |
+| meta_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Request Meta signature is added and signed by each intermediate node.
+
+DEPRECATED: unused and unchecked since API v2.26, use `request_signature` as a verification instead. |
 | origin_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Signature of previous hops.
 
 DEPRECATED: Unused and unchecked since API v2.25, no origin structure to check. |
 | origin | [RequestVerificationHeader](#neo.fs.v2.session.RequestVerificationHeader) |  | Chain of previous hops signatures.
 
 DEPRECATED: Unused and unchecked since API v2.25, no origin structure to check. |
+| request_signature | [neo.fs.v2.refs.Signature](#neo.fs.v2.refs.Signature) |  | Request signature. It is a signature of every request field (except the verification header itself) marshalled and concatenated, e.g. request's body and request's meta header. |
 
 
 <a name="neo.fs.v2.session.ResponseMetaHeader"></a>

--- a/session/types.proto
+++ b/session/types.proto
@@ -280,8 +280,14 @@ message ResponseMetaHeader {
 // Verification info for the request signed by all intermediate nodes.
 message RequestVerificationHeader {
   // Request Body signature. Should be generated once by the request initiator.
+  //
+  // DEPRECATED: unused and unchecked since API v2.26, use `request_signature`
+  // as a verification instead.
   neo.fs.v2.refs.Signature body_signature = 1 [json_name = "bodySignature"];
-  // Request Meta signature is added and signed by each intermediate node
+  // Request Meta signature is added and signed by each intermediate node.
+  //
+  // DEPRECATED: unused and unchecked since API v2.26, use `request_signature`
+  // as a verification instead.
   neo.fs.v2.refs.Signature meta_signature = 2 [json_name = "metaSignature"];
 
   // Signature of previous hops.
@@ -293,6 +299,11 @@ message RequestVerificationHeader {
   //
   // DEPRECATED: Unused and unchecked since API v2.25, no origin structure to check.
   RequestVerificationHeader origin = 4 [json_name = "origin"];
+
+  // Request signature. It is a signature of every request field (except
+  // the verification header itself) marshalled and concatenated, e.g.
+  // request's body and request's meta header.
+  neo.fs.v2.refs.Signature request_signature = 5 [json_name = "requestSignature"];
 }
 
 // Verification info for the response signed by all intermediate nodes


### PR DESCRIPTION
Deprecate the old multi-signature way of request verification. Closes #406.