### PR TITLE
Revert "[#167] netmap: Add attribute escaping description", fix #223

### DIFF
--- a/netmap/types.proto
+++ b/netmap/types.proto
@@ -228,17 +228,6 @@ message NodeInfo {
   // `Attribute` is a Key-Value metadata pair. Key name must be a valid UTF-8
   // string (without zero bytes that are forbidden). Value can't be empty.
   //
-  // Attributes can be constructed into a chain of attributes: any attribute can
-  // have a parent attribute and a child attribute (except the first and the last
-  // one). A string representation of the chain of attributes in NeoFS Storage
-  // Node configuration uses ":" and "/" symbols, e.g.:
-  //
-  //        `NEOFS_NODE_ATTRIBUTE_1=key1:val1/key2:val2`
-  //
-  // Therefore the string attribute representation in the Node configuration must
-  // use "\:", "\/" and "\\" escaped symbols if any of them appears in an attribute's
-  // key or value.
-  //
   // Node's attributes are mostly used during Storage Policy evaluation to
   // calculate object's placement and find a set of nodes satisfying policy
   // requirements. There are some "well-known" node attributes common to all the

--- a/proto-docs/netmap.md
+++ b/proto-docs/netmap.md
@@ -384,17 +384,6 @@ Administrator-defined Attributes of the NeoFS Storage Node.
 `Attribute` is a Key-Value metadata pair. Key name must be a valid UTF-8
 string (without zero bytes that are forbidden). Value can't be empty.
 
-Attributes can be constructed into a chain of attributes: any attribute can
-have a parent attribute and a child attribute (except the first and the last
-one). A string representation of the chain of attributes in NeoFS Storage
-Node configuration uses ":" and "/" symbols, e.g.:
-
-       `NEOFS_NODE_ATTRIBUTE_1=key1:val1/key2:val2`
-
-Therefore the string attribute representation in the Node configuration must
-use "\:", "\/" and "\\" escaped symbols if any of them appears in an attribute's
-key or value.
-
 Node's attributes are mostly used during Storage Policy evaluation to
 calculate object's placement and find a set of nodes satisfying policy
 requirements. There are some "well-known" node attributes common to all the


### PR DESCRIPTION
This reverts commit 2536e5a97b55556fdd4f5db9253c2e14cc9fb75a as inappropriate for API definition. This was a fix for https://github.com/nspcc-dev/neofs-api/issues/165 which leaked some implementation details into API for no real reason, key and value constraints are already defined in the spec and escaping or multi-key handling is out of scope. Also, we don't really have attribute chains, it's all flat KV space, so it's inaccurate and misleading as well.